### PR TITLE
feat: implement fighter streak management with verified anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.0 - 2026-08-07
+
+### Added
+
+- Added verified per-fighter streak anchors with manual and live Tapology provenance, record checks, and admin verification controls.
+- Added a server-only fight-result ledger that recomputes current streaks chronologically and safely handles result corrections.
+
+### Changed
+
+- Existing cached streaks are now treated as unverified until an admin confirms them or a live Tapology profile returns a current MMA streak.
+- Fight-card previews only reuse verified streaks whose expected record matches the current UFC record; historical fight-card snapshots remain unchanged.
+
 ## 0.6.0 - 2026-08-07
 
 ### Security

--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "esbuild": "^0.25.1",
         "lucide-react": "1.26.0",

--- a/Client/package.json
+++ b/Client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/Client/src/EventSelector.css
+++ b/Client/src/EventSelector.css
@@ -1150,6 +1150,18 @@
   font-weight: 700;
 }
 
+.event-admin-stats-editor__row-status .event-admin-stats-editor__streak-status--verified {
+  border-color: rgba(252, 251, 253, 0.3);
+  background: rgba(252, 251, 253, 0.12);
+  color: #FCFBFD;
+}
+
+.event-admin-stats-editor__row-status .event-admin-stats-editor__streak-status--review {
+  border-color: rgba(233, 23, 13, 0.42);
+  background: rgba(233, 23, 13, 0.12);
+  color: #F99EAD;
+}
+
 .event-admin-stats-editor__scrape-button,
 .event-admin-stats-editor__row-save {
   align-self: flex-start;

--- a/Client/src/EventSelector.jsx
+++ b/Client/src/EventSelector.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useLayoutEffect, useCallback, useMemo } from 'react';
-import { RefreshCw, Save } from 'lucide-react';
+import { RefreshCw, Save, ShieldCheck } from 'lucide-react';
 import './EventSelector.css';
 import { API_URL } from './config';
 import { cachedFetchJson, invalidateCache } from './utils/apiCache';
@@ -222,14 +222,31 @@ const countManualPreviewValues = (editableRows, edits) => (
 
 const countMissingEditablePreviewValues = (editableRows) => (
   (editableRows || []).reduce((count, row) => count + FIGHT_CARD_EDITOR_FIELDS.reduce(
-    (fieldCount, [field]) => fieldCount + (normalizeStatEditorValue(row[field]).trim() ? 0 : 1),
+    (fieldCount, [field]) => fieldCount + (
+      normalizeStatEditorValue(row[field]).trim()
+      && (field !== 'Streak' || row?.StreakVerification?.verified)
+        ? 0
+        : 1
+    ),
     0
   ), 0)
 );
 
 const rowHasMissingEditorValues = (row) => FIGHT_CARD_EDITOR_FIELDS.some(
   ([field]) => !normalizeStatEditorValue(row?.[field]).trim()
+    || (field === 'Streak' && !row?.StreakVerification?.verified)
 );
+
+const STREAK_SOURCE_LABELS = {
+  manual: 'Manual',
+  tapology_live: 'Live Tapology',
+  fight_results: 'Fight results',
+};
+
+const getStreakVerificationLabel = (verification) => {
+  if (!verification?.verified) return 'Streak needs verification';
+  return `Streak verified · ${STREAK_SOURCE_LABELS[verification.source] || 'Verified source'}`;
+};
 
 const getEditorValue = (edits, rowId, row, field) => (
   Object.prototype.hasOwnProperty.call(edits?.[rowId] || {}, field)
@@ -633,6 +650,16 @@ function EventSelector({
       return [];
     }
 
+    const streakTotal = Number(summary.streak?.total) || 0;
+    const streakVerified = Object.values(fightCardPreview?.streakVerificationByFighterId || {})
+      .filter((verification) => verification?.verified).length;
+    const verifiedStreakMetric = {
+      field: 'Streak',
+      populated: streakVerified,
+      missing: Math.max(streakTotal - streakVerified, 0),
+      total: streakTotal,
+    };
+
     return [
       {
         key: 'odds',
@@ -646,8 +673,8 @@ function EventSelector({
       },
       {
         key: 'streak',
-        label: formatCompletenessLabel('Streak', summary.streak),
-        tone: getCompletenessTone(summary.streak),
+        label: formatCompletenessLabel('Verified Streak', verifiedStreakMetric),
+        tone: getCompletenessTone(verifiedStreakMetric),
       },
       {
         key: 'finish',
@@ -662,7 +689,12 @@ function EventSelector({
     ];
   }, [fightCardPreview]);
   const editablePreviewRows = useMemo(
-    () => fightCardPreview?.editableRows || [],
+    () => (fightCardPreview?.editableRows || []).map((row) => ({
+      ...row,
+      StreakVerification: fightCardPreview?.streakVerificationByFighterId?.[row.fighterId]
+        || fightCardPreview?.streakVerificationByFighterId?.[String(row.fighterId)]
+        || null,
+    })),
     [fightCardPreview]
   );
   const manualPreviewUpdates = useMemo(
@@ -1198,6 +1230,57 @@ function EventSelector({
     }
   };
 
+  const handleVerifyFightStatsStreak = async (event, row) => {
+    if (!event?.id || !row?.id) return;
+    const streak = normalizeStatEditorValue(
+      getEditorValue(fightStatsEdits, row.id, row, 'Streak')
+    ).trim();
+    if (!streak || !isValidStatEditorValue('signed-number', streak)) return;
+
+    setFightCardFeedback(null);
+    setSavingFightStatsEventId(event.id);
+    setSavingFightStatsRowId(row.id);
+    try {
+      const response = await fetchWithAdminSession(
+        `${API_URL}/admin/events/${event.id}/fight-card/stats/${row.id}/verify-streak`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ streak }),
+        }
+      );
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(buildApiErrorMessage(payload, 'Failed to verify fighter streak'));
+      }
+
+      const reloadResponse = await fetchWithAdminSession(
+        `${API_URL}/admin/events/${event.id}/fight-card/stats`,
+        { method: 'GET', headers: { 'Content-Type': 'application/json' } }
+      );
+      const reloadPayload = await reloadResponse.json().catch(() => ({}));
+      if (!reloadResponse.ok) {
+        throw new Error(buildApiErrorMessage(reloadPayload, 'Verified streak, but failed to reload rows'));
+      }
+      setFightStatsRows(reloadPayload.rows || []);
+      setFightStatsEdits((current) => omitEditFields(current, { [row.id]: ['Streak'] }));
+      invalidateEventCaches(event.id);
+      onFightCardImportComplete?.(event.id);
+      setFightCardFeedback({
+        type: 'success',
+        message: `Verified ${[row.FirstName, row.LastName].filter(Boolean).join(' ') || 'fighter'} at ${streak > 0 ? `+${streak}` : streak}.`,
+      });
+    } catch (err) {
+      setFightCardFeedback({
+        type: 'error',
+        message: err.message || 'Failed to verify fighter streak',
+      });
+    } finally {
+      setSavingFightStatsEventId(null);
+      setSavingFightStatsRowId(null);
+    }
+  };
+
   const handleScrapeTapologyFighterStats = async (event, row) => {
     if (!event?.id || !row?.id) return;
 
@@ -1453,6 +1536,46 @@ function EventSelector({
       setFightCardFeedback({
         type: 'error',
         message: err.message || 'Failed to save preview progress'
+      });
+    } finally {
+      setSavingPreviewProgressRowKey(null);
+    }
+  };
+
+  const handleVerifyPreviewStreak = async (event, row) => {
+    if (!event?.id || !row?.rowKey || !fightCardPreview?.previewToken) return;
+    const streak = normalizeStatEditorValue(
+      getEditorValue(fightCardPreviewEdits, row.rowKey, row, 'Streak')
+    ).trim();
+    if (!streak || !isValidStatEditorValue('signed-number', streak)) return;
+
+    setFightCardFeedback(null);
+    setSavingPreviewProgressRowKey(row.rowKey);
+    try {
+      const response = await fetchWithAdminSession(
+        `${API_URL}/admin/events/${event.id}/fight-card/preview/${fightCardPreview.previewToken}/verify-streak`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ rowKey: row.rowKey, streak }),
+        }
+      );
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(buildApiErrorMessage(payload, 'Failed to verify fighter streak'));
+      }
+      setFightCardPreview(payload);
+      setFightCardPreviewEdits((current) => omitEditFields(current, {
+        [row.rowKey]: ['Streak'],
+      }));
+      setFightCardFeedback({
+        type: 'success',
+        message: `Verified ${getEditablePreviewFighterName(row)} at ${streak > 0 ? `+${streak}` : streak}.${payload.isImported ? ' The fight card was updated.' : ''}`,
+      });
+    } catch (err) {
+      setFightCardFeedback({
+        type: 'error',
+        message: err.message || 'Failed to verify fighter streak',
       });
     } finally {
       setSavingPreviewProgressRowKey(null);
@@ -1826,8 +1949,19 @@ function EventSelector({
                       <div className="event-admin-import-preview__edit-list">
                         {visibleFightStatsRows.map((row) => {
                           const rowUpdate = fightStatsUpdates.find((update) => String(update.id) === String(row.id));
+                          const streakVerification = row.StreakVerification;
+                          const editedStreak = normalizeStatEditorValue(
+                            getEditorValue(fightStatsEdits, row.id, row, 'Streak')
+                          ).trim();
+                          const canVerifyStreak = Boolean(editedStreak)
+                            && isValidStatEditorValue('signed-number', editedStreak);
                           const rowMissingCount = FIGHT_CARD_EDITOR_FIELDS.reduce(
-                            (count, [field]) => count + (normalizeStatEditorValue(row[field]).trim() ? 0 : 1),
+                            (count, [field]) => count + (
+                              normalizeStatEditorValue(row[field]).trim()
+                              && (field !== 'Streak' || streakVerification?.verified)
+                                ? 0
+                                : 1
+                            ),
                             0
                           );
                           return (
@@ -1843,6 +1977,11 @@ function EventSelector({
                                 <div className="event-admin-stats-editor__row-status">
                                   {rowMissingCount > 0 && <span>{rowMissingCount} missing</span>}
                                   {rowUpdate && <span>{Object.keys(rowUpdate.values).length} changed</span>}
+                                  <span className={streakVerification?.verified
+                                    ? 'event-admin-stats-editor__streak-status--verified'
+                                    : 'event-admin-stats-editor__streak-status--review'}>
+                                    {getStreakVerificationLabel(streakVerification)}
+                                  </span>
                                 </div>
                                 <div className="event-admin-stats-editor__row-actions">
                                   <button
@@ -1855,6 +1994,18 @@ function EventSelector({
                                     <RefreshCw size={14} aria-hidden="true" />
                                     {scrapingTapologyRowId === row.id ? 'Scraping...' : 'Scrape'}
                                   </button>
+                                  {!streakVerification?.verified && (
+                                    <button
+                                      type="button"
+                                      className="event-admin-stats-editor__row-save"
+                                      onClick={() => handleVerifyFightStatsStreak(selectedEvent, row)}
+                                      disabled={isFightCardActionBusy || !canVerifyStreak}
+                                      title="Confirm this streak as the trusted starting value"
+                                    >
+                                      <ShieldCheck size={14} aria-hidden="true" />
+                                      Verify Streak
+                                    </button>
+                                  )}
                                   <button
                                     type="button"
                                     className="event-admin-stats-editor__row-save"
@@ -2007,6 +2158,12 @@ function EventSelector({
                         <div className="event-admin-import-preview__edit-list">
                           {visiblePreviewRows.map((row) => {
                             const rowPatch = manualPreviewUpdates[row.rowKey];
+                            const streakVerification = row.StreakVerification;
+                            const editedStreak = normalizeStatEditorValue(
+                              getEditorValue(fightCardPreviewEdits, row.rowKey, row, 'Streak')
+                            ).trim();
+                            const canVerifyStreak = Boolean(editedStreak)
+                              && isValidStatEditorValue('signed-number', editedStreak);
                             const rowTapologyUrl = normalizeStatEditorValue(
                               getEditorValue(fightCardPreviewEdits, row.rowKey, row, 'TapologyFighterURL')
                             ).trim();
@@ -2014,7 +2171,12 @@ function EventSelector({
                               && isValidStatEditorValue('url', rowTapologyUrl);
                             const isScrapingTapologyRow = scrapingPreviewTapologyRowKeys.includes(row.rowKey);
                             const rowMissingCount = FIGHT_CARD_EDITOR_FIELDS.reduce(
-                              (count, [field]) => count + (normalizeStatEditorValue(row[field]).trim() ? 0 : 1),
+                              (count, [field]) => count + (
+                                normalizeStatEditorValue(row[field]).trim()
+                                && (field !== 'Streak' || streakVerification?.verified)
+                                  ? 0
+                                  : 1
+                              ),
                               0
                             );
                             return (
@@ -2025,6 +2187,11 @@ function EventSelector({
                                   <div className="event-admin-stats-editor__row-status">
                                     {rowMissingCount > 0 && <span>{rowMissingCount} missing</span>}
                                     {rowPatch && <span>{Object.keys(rowPatch).length} changed</span>}
+                                    <span className={streakVerification?.verified
+                                      ? 'event-admin-stats-editor__streak-status--verified'
+                                      : 'event-admin-stats-editor__streak-status--review'}>
+                                      {getStreakVerificationLabel(streakVerification)}
+                                    </span>
                                   </div>
                                   <div className="event-admin-stats-editor__row-actions">
                                     <button
@@ -2039,6 +2206,18 @@ function EventSelector({
                                       <RefreshCw size={14} aria-hidden="true" />
                                       {isScrapingTapologyRow ? 'Scraping...' : 'Scrape'}
                                     </button>
+                                    {!streakVerification?.verified && (
+                                      <button
+                                        type="button"
+                                        className="event-admin-stats-editor__row-save"
+                                        onClick={() => handleVerifyPreviewStreak(selectedEvent, row)}
+                                        disabled={isFightCardActionBusy || !canVerifyStreak}
+                                        title="Confirm this streak as the trusted starting value"
+                                      >
+                                        <ShieldCheck size={14} aria-hidden="true" />
+                                        Verify Streak
+                                      </button>
+                                    )}
                                     <button
                                       type="button"
                                       className="event-admin-stats-editor__row-save"

--- a/Server/index.js
+++ b/Server/index.js
@@ -23,6 +23,13 @@ const {
   syncFighterStyleFromFightCardRows,
 } = require('./lib/fighterStyleSync');
 const {
+  buildStreakAnchorPayload,
+  isVerifiedStreakProfile,
+  replayStreakFromAnchor,
+  streakRecordMatches,
+  toDateOnly,
+} = require('./lib/fighterStreaks');
+const {
   buildFightResponse,
   buildWeightclassMap,
   normalizeWeightclass,
@@ -657,59 +664,219 @@ function normalizeFiniteInteger(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-const CURRENT_FIGHTER_STREAK_SOURCES = new Set([
-  'cached_profile_url',
-  'fight_result',
-  'live_profile',
-  'manual_streak',
-  'tapology_partial_profile',
-  'tapology_single_profile',
-  'tapology_wikipedia_merged',
-  'wikipedia_record_breakdown',
-]);
+const FIGHTER_STREAK_PROFILE_SELECT = [
+  'fighter_id',
+  'streak',
+  'streak_source',
+  'streak_anchor_source',
+  'streak_verified_at',
+  'streak_anchor_value',
+  'streak_anchor_record_wins',
+  'streak_anchor_record_losses',
+  'streak_anchor_event_id',
+  'streak_anchor_through_date',
+  'streak_record_wins',
+  'streak_record_losses',
+  'streak_verified_through_date',
+  'streak_needs_review',
+].join(',');
 
-function currentFighterProfileStreak(profile) {
-  const source = String(profile?.stats_source || '').trim().toLowerCase();
-  if (!CURRENT_FIGHTER_STREAK_SOURCES.has(source)) {
-    return null;
-  }
-  return normalizeFiniteInteger(profile?.streak);
+function buildStreakVerificationSummary(profile, row = null) {
+  const recordMatches = row
+    ? streakRecordMatches(profile, row.Record_Wins, row.Record_Losses)
+    : null;
+  const verified = isVerifiedStreakProfile(profile) && recordMatches !== false;
+
+  return {
+    verified,
+    needsReview: Boolean(profile?.streak_needs_review) || recordMatches === false,
+    source: profile?.streak_source || null,
+    anchorSource: profile?.streak_anchor_source || null,
+    verifiedAt: profile?.streak_verified_at || null,
+    verifiedThroughDate: profile?.streak_verified_through_date || null,
+    recordMatches,
+  };
 }
 
-function nextFighterStreak(currentStreak, won) {
-  const baseline = Number.isFinite(currentStreak) ? currentStreak : 0;
-  if (won) {
-    return baseline > 0 ? baseline + 1 : 1;
+async function loadStreakVerificationByFighterId(rows) {
+  const fighterIds = Array.from(new Set(
+    (rows || [])
+      .map((row) => Number(row?.FighterId ?? row?.fighterId))
+      .filter(Number.isFinite)
+  ));
+  if (fighterIds.length === 0) {
+    return {};
   }
-  return baseline < 0 ? baseline - 1 : -1;
+
+  const fightIds = Array.from(new Set(
+    (rows || []).map((row) => Number(row?.FightId ?? row?.fightId)).filter(Number.isFinite)
+  ));
+  const [profileResponse, resultResponse] = await Promise.all([
+    supabase
+      .from('fighters')
+      .select(FIGHTER_STREAK_PROFILE_SELECT)
+      .in('fighter_id', fighterIds),
+    fightIds.length > 0
+      ? supabase
+          .from('fight_results')
+          .select('fight_id,fighter_id,is_completed')
+          .in('fight_id', fightIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  const { data, error } = profileResponse;
+  if (error) {
+    throw new Error(`Failed to load fighter streak verification: ${error.message}`);
+  }
+  if (resultResponse.error) {
+    throw new Error(`Failed to load fight results for streak verification: ${resultResponse.error.message}`);
+  }
+
+  const profilesById = new Map((data || []).map((profile) => [Number(profile.fighter_id), profile]));
+  const resultsByFightId = new Map(
+    (resultResponse.data || []).map((result) => [Number(result.fight_id), result])
+  );
+  return Object.fromEntries(fighterIds.map((fighterId) => {
+    const row = (rows || []).find(
+      (candidate) => Number(candidate?.FighterId ?? candidate?.fighterId) === fighterId
+    );
+    const result = resultsByFightId.get(Number(row?.FightId ?? row?.fightId));
+    let comparisonRow = row;
+    if (result?.is_completed === true && row) {
+      const won = Number(result.fighter_id) === fighterId;
+      const wins = normalizeFiniteInteger(row.Record_Wins);
+      const losses = normalizeFiniteInteger(row.Record_Losses);
+      comparisonRow = {
+        ...row,
+        Record_Wins: Number.isFinite(wins) ? wins + (won ? 1 : 0) : row.Record_Wins,
+        Record_Losses: Number.isFinite(losses) ? losses + (won ? 0 : 1) : row.Record_Losses,
+      };
+    }
+    return [fighterId, buildStreakVerificationSummary(profilesById.get(fighterId), comparisonRow)];
+  }));
 }
 
-function undoFighterStreakResult(currentStreak, won) {
-  const baseline = Number.isFinite(currentStreak) ? currentStreak : 0;
-  if (won) {
-    return baseline > 1 ? baseline - 1 : 0;
-  }
-  return baseline < -1 ? baseline + 1 : 0;
+async function decorateRowsWithStreakVerification(rows) {
+  const verificationByFighterId = await loadStreakVerificationByFighterId(rows);
+  return (rows || []).map((row) => ({
+    ...row,
+    StreakVerification: verificationByFighterId[Number(row.FighterId)] || {
+      verified: false,
+      needsReview: true,
+      source: null,
+      anchorSource: null,
+      verifiedAt: null,
+      verifiedThroughDate: null,
+      recordMatches: null,
+    },
+  }));
 }
 
-async function updateFighterStreaksForCompletedFight({
+async function persistVerifiedStreakAnchor({ row, eventId, streak, source }) {
+  const fighterId = Number(row?.FighterId);
+  if (!Number.isFinite(fighterId)) {
+    throw new Error('A fighter id is required to verify streak');
+  }
+
+  const fightId = Number(row?.FightId);
+  let fightCompleted = false;
+  let anchorRow = row;
+  if (Number.isFinite(fightId)) {
+    const { data: result, error: resultError } = await supabase
+      .from('fight_results')
+      .select('fighter_id,is_completed')
+      .eq('fight_id', fightId)
+      .maybeSingle();
+    if (resultError) {
+      throw new Error(`Failed to check the fight result before verifying streak: ${resultError.message}`);
+    }
+    fightCompleted = result?.is_completed === true;
+    if (fightCompleted) {
+      const won = Number(result.fighter_id) === fighterId;
+      const recordWins = normalizeFiniteInteger(row?.Record_Wins);
+      const recordLosses = normalizeFiniteInteger(row?.Record_Losses);
+      anchorRow = {
+        ...row,
+        Record_Wins: Number.isFinite(recordWins) ? recordWins + (won ? 1 : 0) : row?.Record_Wins,
+        Record_Losses: Number.isFinite(recordLosses) ? recordLosses + (won ? 0 : 1) : row?.Record_Losses,
+      };
+    }
+  }
+
+  const nowIso = new Date().toISOString();
+  const anchor = buildStreakAnchorPayload({
+    row: anchorRow,
+    streak,
+    source,
+    eventId,
+    eventDate: row?.StartTime,
+    fightCompleted,
+    verifiedAt: nowIso,
+  });
+  const payload = compactNonNullPayload({
+    fighter_id: fighterId,
+    mma_id: row.MMAId ?? null,
+    first_name: row.FirstName ?? null,
+    last_name: row.LastName ?? null,
+    normalized_name: normalizeFighterNameForLookup(row.FirstName, row.LastName) || null,
+    ...anchor,
+    stats_source: source === 'manual' ? 'manual_streak' : 'tapology_live',
+    stats_confidence: source === 'manual' ? 'manual_streak' : 'live-profile-streak',
+    stats_as_of_event_id: Number.isFinite(Number(eventId)) ? Number(eventId) : null,
+    stats_as_of_event_date: toDateOnly(row?.StartTime),
+    last_success_at: nowIso,
+  });
+
+  const { error } = await supabase
+    .from('fighters')
+    .upsert([payload], { onConflict: 'fighter_id' });
+  if (error) {
+    throw new Error(`Failed to save verified fighter streak: ${error.message}`);
+  }
+
+  return buildStreakVerificationSummary(payload, anchorRow);
+}
+
+async function persistManualStreakAnchors({ eventId, preview, manualRowUpdates }) {
+  const rowsByKey = new Map(
+    (preview?.rows || []).map((row) => [buildFightCardPreviewRowKey(row), row])
+  );
+  const verified = {};
+
+  for (const [rowKey, values] of Object.entries(manualRowUpdates || {})) {
+    if (!values || !Object.prototype.hasOwnProperty.call(values, 'Streak')) {
+      continue;
+    }
+    const row = rowsByKey.get(rowKey);
+    if (!row || values.Streak === null || values.Streak === '') {
+      continue;
+    }
+    verified[Number(row.FighterId)] = await persistVerifiedStreakAnchor({
+      row: { ...row, Streak: values.Streak },
+      eventId,
+      streak: values.Streak,
+      source: 'manual',
+    });
+  }
+
+  return verified;
+}
+
+async function updateFighterStreaksForFightResult({
   fightId,
   winnerId,
-  previousWinnerId = null,
 }) {
   const normalizedFightId = Number(fightId);
-  const normalizedWinnerId = Number(winnerId);
-  const normalizedPreviousWinnerId = previousWinnerId === null || previousWinnerId === undefined
+  const normalizedWinnerId = winnerId === null || winnerId === undefined
     ? null
-    : Number(previousWinnerId);
+    : Number(winnerId);
 
-  if (!Number.isFinite(normalizedFightId) || !Number.isFinite(normalizedWinnerId)) {
+  if (!Number.isFinite(normalizedFightId) || (normalizedWinnerId !== null && !Number.isFinite(normalizedWinnerId))) {
     return { skipped: true, reason: 'Invalid fight or winner id', updates: [] };
   }
 
   const { data: fightRows, error: fightRowsError } = await supabase
     .from('ufc_full_fight_card')
-    .select('id,FightId,EventId,StartTime,Corner,FighterId,MMAId,FirstName,LastName,Streak')
+    .select('id,FightId,EventId,StartTime,Corner,FighterId,MMAId,FirstName,LastName,Record_Wins,Record_Losses,Streak')
     .eq('FightId', normalizedFightId);
 
   if (fightRowsError) {
@@ -722,17 +889,47 @@ async function updateFighterStreaksForCompletedFight({
   }
 
   const fighterIds = eligibleRows.map((row) => Number(row.FighterId));
+  const eventDate = toDateOnly(eligibleRows[0]?.StartTime);
+  const eventId = Number(eligibleRows[0]?.EventId);
+  if (!eventDate || !Number.isFinite(eventId)) {
+    return { skipped: true, reason: 'Fight-card event date is unavailable', updates: [] };
+  }
+
+  if (normalizedWinnerId === null) {
+    const { error: deleteLedgerError } = await supabase
+      .from('fighter_streak_results')
+      .delete()
+      .eq('fight_id', normalizedFightId);
+    if (deleteLedgerError) {
+      throw new Error(`Failed to remove fighter streak result ledger rows: ${deleteLedgerError.message}`);
+    }
+  } else {
+    const ledgerRows = eligibleRows.map((row) => ({
+      fighter_id: Number(row.FighterId),
+      fight_id: normalizedFightId,
+      event_id: eventId,
+      event_date: eventDate,
+      outcome: Number(row.FighterId) === normalizedWinnerId ? 'win' : 'loss',
+    }));
+    const { error: ledgerError } = await supabase
+      .from('fighter_streak_results')
+      .upsert(ledgerRows, { onConflict: 'fighter_id,fight_id' });
+    if (ledgerError) {
+      throw new Error(`Failed to save fighter streak result ledger rows: ${ledgerError.message}`);
+    }
+  }
+
   const { data: fighterProfiles, error: fighterProfilesError } = await supabase
     .from('fighters')
-    .select('fighter_id,streak,stats_source')
+    .select(FIGHTER_STREAK_PROFILE_SELECT)
     .in('fighter_id', fighterIds);
 
   if (fighterProfilesError) {
     throw new Error(`Failed to load fighter profiles for streak update: ${fighterProfilesError.message}`);
   }
 
-  const currentStreakByFighterId = new Map(
-    (fighterProfiles || []).map((row) => [Number(row.fighter_id), currentFighterProfileStreak(row)])
+  const fighterProfileById = new Map(
+    (fighterProfiles || []).map((row) => [Number(row.fighter_id), row])
   );
   const nowIso = new Date().toISOString();
   const fighterProfilePayloads = [];
@@ -740,28 +937,68 @@ async function updateFighterStreaksForCompletedFight({
 
   for (const row of eligibleRows) {
     const fighterId = Number(row.FighterId);
-    const rowStreak = normalizeFiniteInteger(row.Streak);
-    const currentStreak = currentStreakByFighterId.get(fighterId);
-    let baselineStreak = currentStreak;
-
-    if (baselineStreak === null || baselineStreak === undefined) {
-      baselineStreak = rowStreak;
-    }
-    if (!Number.isFinite(baselineStreak)) {
-      baselineStreak = 0;
-    }
-
-    let adjustedBaseline = baselineStreak;
-    if (Number.isFinite(normalizedPreviousWinnerId)) {
-      adjustedBaseline = undoFighterStreakResult(
-        adjustedBaseline,
-        fighterId === normalizedPreviousWinnerId
-      );
+    const profile = fighterProfileById.get(fighterId);
+    if (!isVerifiedStreakProfile(profile)) {
+      updates.push({
+        fighterId,
+        skipped: true,
+        reason: 'Fighter does not have a verified streak anchor',
+      });
+      continue;
     }
 
-    const won = fighterId === normalizedWinnerId;
-    const nextStreak = nextFighterStreak(adjustedBaseline, won);
-    const eventId = Number(row.EventId);
+    const { data: resultRows, error: resultRowsError } = await supabase
+      .from('fighter_streak_results')
+      .select('fighter_id,fight_id,event_id,event_date,outcome')
+      .eq('fighter_id', fighterId)
+      .order('event_date', { ascending: true })
+      .order('event_id', { ascending: true })
+      .order('fight_id', { ascending: true });
+    if (resultRowsError) {
+      throw new Error(`Failed to replay fighter streak results: ${resultRowsError.message}`);
+    }
+
+    const rowsBeforeFight = (resultRows || []).filter((resultRow) => (
+      String(resultRow.event_date).localeCompare(eventDate) < 0
+      || (
+        String(resultRow.event_date) === eventDate
+        && (
+          Number(resultRow.event_id) < eventId
+          || (
+            Number(resultRow.event_id) === eventId
+            && Number(resultRow.fight_id) < normalizedFightId
+          )
+        )
+      )
+    ));
+    const preFightReplay = replayStreakFromAnchor(profile, rowsBeforeFight);
+    const preFightRecordMatches = preFightReplay.ok
+      ? streakRecordMatches({
+          streak_record_wins: preFightReplay.recordWins,
+          streak_record_losses: preFightReplay.recordLosses,
+        }, row.Record_Wins, row.Record_Losses)
+      : null;
+    if (preFightRecordMatches === false) {
+      const { error: reviewError } = await supabase
+        .from('fighters')
+        .update({ streak_needs_review: true })
+        .eq('fighter_id', fighterId);
+      if (reviewError) {
+        throw new Error(`Failed to flag fighter streak for review: ${reviewError.message}`);
+      }
+      updates.push({
+        fighterId,
+        skipped: true,
+        reason: 'Fight-card record does not match the verified streak record',
+      });
+      continue;
+    }
+
+    const replay = replayStreakFromAnchor(profile, resultRows || []);
+    if (!replay.ok) {
+      updates.push({ fighterId, skipped: true, reason: replay.reason });
+      continue;
+    }
 
     fighterProfilePayloads.push(compactNonNullPayload({
       fighter_id: fighterId,
@@ -769,7 +1006,12 @@ async function updateFighterStreaksForCompletedFight({
       first_name: row.FirstName ?? null,
       last_name: row.LastName ?? null,
       normalized_name: normalizeFighterNameForLookup(row.FirstName, row.LastName) || null,
-      streak: nextStreak,
+      streak: replay.streak,
+      streak_source: 'fight_results',
+      streak_record_wins: replay.recordWins,
+      streak_record_losses: replay.recordLosses,
+      streak_verified_through_date: replay.verifiedThroughDate,
+      streak_needs_review: false,
       stats_source: 'fight_result',
       stats_confidence: 'fight_result',
       stats_as_of_event_id: Number.isFinite(eventId) ? eventId : null,
@@ -780,12 +1022,11 @@ async function updateFighterStreaksForCompletedFight({
     }));
 
     updates.push({
-      rowId: row.id,
       fighterId,
-      previousStreak: baselineStreak,
-      adjustedBaseline,
-      nextStreak,
-      won,
+      skipped: false,
+      previousStreak: normalizeFiniteInteger(profile.streak),
+      nextStreak: replay.streak,
+      appliedResultCount: replay.appliedResultCount,
     });
   }
 
@@ -954,6 +1195,7 @@ async function persistScrapedTapologyFighterProfile({
   profile,
   statsSource,
   statsConfidence,
+  verifyLiveStreak = false,
 }) {
   const fighterId = Number(row?.FighterId);
   if (!Number.isFinite(fighterId)) {
@@ -961,6 +1203,7 @@ async function persistScrapedTapologyFighterProfile({
   }
 
   const nowIso = new Date().toISOString();
+  const scrapedStreak = parseOptionalInteger(profile.Streak);
   const baseProfilePayload = {
     fighter_id: fighterId,
     mma_id: row.MMAId ?? null,
@@ -969,7 +1212,6 @@ async function persistScrapedTapologyFighterProfile({
     normalized_name: normalizeFighterNameForLookup(row.FirstName, row.LastName) || null,
     tapology_fighter_url: tapologyFighterUrl,
     rank: parseOptionalInteger(profile.Rank),
-    streak: parseOptionalInteger(profile.Streak),
     style: normalizeAdminStatValue('style', profile.style).value,
     ko_tko_wins: normalizeAdminStatValue('KO_TKO_Wins', profile.KO_TKO_Wins).value,
     ko_tko_losses: normalizeAdminStatValue('KO_TKO_Losses', profile.KO_TKO_Losses).value,
@@ -981,17 +1223,7 @@ async function persistScrapedTapologyFighterProfile({
     last_failure_at: null,
     last_error: null,
   };
-  const fightersPayload = compactNonNullPayload({
-    ...baseProfilePayload,
-    ...(baseProfilePayload.streak !== null ? {
-      stats_source: statsSource,
-      stats_confidence: statsConfidence,
-      stats_as_of_event_id: eventId,
-      stats_as_of_event_date: typeof row.StartTime === 'string'
-        ? row.StartTime.split('T')[0]
-        : null,
-    } : {}),
-  });
+  const fightersPayload = compactNonNullPayload(baseProfilePayload);
 
   const { error: fightersError } = await supabase
     .from('fighters')
@@ -1003,6 +1235,7 @@ async function persistScrapedTapologyFighterProfile({
 
   const tapologyCachePayload = compactNonNullPayload({
     ...baseProfilePayload,
+    streak: scrapedStreak,
     source: statsSource,
     match_confidence: statsConfidence,
   });
@@ -1014,9 +1247,19 @@ async function persistScrapedTapologyFighterProfile({
     console.error('Tapology fighter cache update skipped:', tapologyCacheError);
   }
 
+  const streakVerification = verifyLiveStreak && scrapedStreak !== null
+    ? await persistVerifiedStreakAnchor({
+        row: { ...row, Streak: scrapedStreak },
+        eventId,
+        streak: scrapedStreak,
+        source: 'tapology_live',
+      })
+    : null;
+
   return {
     updatedFighters: 1,
     updatedTapologyCacheRows: tapologyCacheError ? 0 : 1,
+    streakVerification,
   };
 }
 
@@ -1080,7 +1323,6 @@ async function persistImportedFightCardPreviewUpdates({
 
   let updatedFightCardRows = 0;
   const fighterProfilePayloadById = new Map();
-  const nowIso = new Date().toISOString();
 
   for (const { importedRow, patch } of normalizedUpdates) {
     const { error: updateError } = await supabase
@@ -1105,7 +1347,7 @@ async function persistImportedFightCardPreviewUpdates({
 
     const fighterProfileEntries = Object.entries(patch)
       .map(([field, value]) => [toFighterProfileColumn(field), field, value])
-      .filter(([profileColumn]) => Boolean(profileColumn));
+      .filter(([profileColumn, field]) => Boolean(profileColumn) && field !== 'Streak');
     if (fighterProfileEntries.length === 0) {
       continue;
     }
@@ -1118,17 +1360,8 @@ async function persistImportedFightCardPreviewUpdates({
       normalized_name: normalizeFighterNameForLookup(importedRow.FirstName, importedRow.LastName) || null,
     };
 
-    for (const [profileColumn, field, value] of fighterProfileEntries) {
+    for (const [profileColumn, , value] of fighterProfileEntries) {
       payload[profileColumn] = value;
-      if (field === 'Streak') {
-        payload.stats_source = 'manual_streak';
-        payload.stats_confidence = 'manual_streak';
-        payload.stats_as_of_event_id = eventId;
-        payload.stats_as_of_event_date = typeof importedRow.StartTime === 'string'
-          ? importedRow.StartTime.split('T')[0]
-          : null;
-        payload.last_success_at = nowIso;
-      }
     }
 
     fighterProfilePayloadById.set(fighterId, payload);
@@ -2640,33 +2873,24 @@ app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res
 
     let fighterStreakSync = {
       skipped: true,
-      reason: 'Fight result is not completed',
+      reason: 'Fight result did not change',
       updates: [],
     };
     const previousWinnerId = existingResult?.is_completed && existingResult?.fighter_id !== null
       ? Number(existingResult.fighter_id)
       : null;
-    const sameCompletedWinner = winner_id !== null
-      && Number.isFinite(previousWinnerId)
-      && previousWinnerId === winner_id;
+    const resultChanged = previousWinnerId !== winner_id;
 
-    if (winner_id !== null && !sameCompletedWinner) {
+    if (resultChanged) {
       try {
-        fighterStreakSync = await updateFighterStreaksForCompletedFight({
+        fighterStreakSync = await updateFighterStreaksForFightResult({
           fightId: id,
           winnerId: winner_id,
-          previousWinnerId,
         });
       } catch (fighterStreakError) {
         console.error('Error updating fighter streaks from fight result:', fighterStreakError);
         return res.status(500).json({ error: 'Failed to update fighter streaks' });
       }
-    } else if (sameCompletedWinner) {
-      fighterStreakSync = {
-        skipped: true,
-        reason: 'Fight result winner was already recorded',
-        updates: [],
-      };
     }
 
     try {
@@ -3913,6 +4137,7 @@ app.post('/admin/events/:id/fight-card/preview', requireAdminSession, async (req
       existingFightResults,
       scraperOutput,
     });
+    preview.streakVerificationByFighterId = await loadStreakVerificationByFighterId(preview.rows);
 
     const { rows, ...previewSummary } = preview;
 
@@ -4015,6 +4240,15 @@ app.post('/admin/events/:id/fight-card/preview/:previewToken/progress', requireA
       preview: result.preview,
       manualRowUpdates: req.body?.manualRowUpdates,
     });
+    const verifiedStreaks = await persistManualStreakAnchors({
+      eventId,
+      preview: result.preview,
+      manualRowUpdates: req.body?.manualRowUpdates,
+    });
+    result.preview.streakVerificationByFighterId = {
+      ...(result.preview.streakVerificationByFighterId || {}),
+      ...verifiedStreaks,
+    };
 
     const { rows, scratchDir, ...previewSummary } = result.preview;
     await logAdminAction(req, {
@@ -4027,18 +4261,100 @@ app.post('/admin/events/:id/fight-card/preview/:previewToken/progress', requireA
         applied_manual_update_count: result.appliedManualUpdateCount,
         updated_fight_card_rows: persistence.updatedFightCardRows,
         updated_fighters: persistence.updatedFighters,
+        verified_streaks: Object.keys(verifiedStreaks).length,
       },
     });
 
     return res.json({
       ...previewSummary,
       appliedManualUpdateCount: result.appliedManualUpdateCount,
+      verifiedStreakCount: Object.keys(verifiedStreaks).length,
       ...persistence,
     });
   } catch (error) {
     console.error('Error saving fight-card preview progress:', error);
     return res.status(500).json({
       error: 'Failed to save fight-card preview progress',
+      details: error.message,
+    });
+  }
+});
+
+app.post('/admin/events/:id/fight-card/preview/:previewToken/verify-streak', requireAdminSession, async (req, res) => {
+  res.set('Cache-Control', 'no-store');
+
+  try {
+    const eventId = Number(req.params.id);
+    const previewToken = String(req.params.previewToken || '').trim();
+    const rowKey = String(req.body?.rowKey || '').trim();
+    const normalizedStreak = normalizeAdminStatValue('Streak', req.body?.streak);
+    if (Number.isNaN(eventId) || !previewToken || !rowKey) {
+      return res.status(400).json({ error: 'Invalid event id, preview token, or fighter row' });
+    }
+    if (!normalizedStreak.ok || normalizedStreak.value === null) {
+      return res.status(400).json({ error: normalizedStreak.error || 'Enter a streak before verifying it' });
+    }
+
+    await cleanupExpiredFightCardPreviews();
+    const preview = getFightCardPreview(previewToken, eventId);
+    if (!preview) {
+      return res.status(404).json({ error: 'Preview token was not found or has expired' });
+    }
+    const row = (preview.rows || []).find(
+      (candidate) => buildFightCardPreviewRowKey(candidate) === rowKey
+    );
+    if (!row) {
+      return res.status(404).json({ error: 'Fighter row was not found in this preview' });
+    }
+
+    const progress = saveFightCardPreviewProgress(previewToken, eventId, {
+      [rowKey]: { Streak: normalizedStreak.value },
+    });
+    if (!progress) {
+      return res.status(404).json({ error: 'Preview token was not found or has expired' });
+    }
+    const persistence = await persistImportedFightCardPreviewUpdates({
+      eventId,
+      preview: progress.preview,
+      manualRowUpdates: { [rowKey]: { Streak: normalizedStreak.value } },
+      updateFighterProfiles: false,
+    });
+    const streakVerification = await persistVerifiedStreakAnchor({
+      row: { ...row, Streak: normalizedStreak.value },
+      eventId,
+      streak: normalizedStreak.value,
+      source: 'manual',
+    });
+    progress.preview.streakVerificationByFighterId = {
+      ...(progress.preview.streakVerificationByFighterId || {}),
+      [Number(row.FighterId)]: streakVerification,
+    };
+
+    const { rows, scratchDir, ...previewSummary } = progress.preview;
+    await logAdminAction(req, {
+      action: 'fight_card.preview.verify_streak',
+      status: 'success',
+      targetType: 'event',
+      targetId: eventId,
+      eventId,
+      metadata: {
+        rowKey,
+        fighterId: row.FighterId,
+        streak: normalizedStreak.value,
+      },
+    });
+
+    return res.json({
+      ...previewSummary,
+      rowKey,
+      fighterId: row.FighterId,
+      streakVerification,
+      ...persistence,
+    });
+  } catch (error) {
+    console.error('Error verifying preview fighter streak:', error);
+    return res.status(500).json({
+      error: 'Failed to verify fighter streak',
       details: error.message,
     });
   }
@@ -4105,6 +4421,7 @@ app.post('/admin/events/:id/fight-card/preview/:previewToken/scrape-tapology', r
       profile,
       statsSource,
       statsConfidence,
+      verifyLiveStreak: scrapeResult?.diagnostics?.tapology_fetch_status === 'success',
     });
     const progress = saveFightCardPreviewProgress(previewToken, eventId, {
       [rowKey]: patch,
@@ -4118,6 +4435,12 @@ app.post('/admin/events/:id/fight-card/preview/:previewToken/scrape-tapology', r
       manualRowUpdates: { [rowKey]: patch },
       updateFighterProfiles: false,
     });
+    if (profilePersistence.streakVerification) {
+      progress.preview.streakVerificationByFighterId = {
+        ...(progress.preview.streakVerificationByFighterId || {}),
+        [Number(row.FighterId)]: profilePersistence.streakVerification,
+      };
+    }
     const { rows, scratchDir, ...previewSummary } = progress.preview;
     const updatedFields = Object.keys(patch).filter((field) => field !== 'TapologyFighterURL');
     const scrapeDiagnostics = buildTapologyScrapeDiagnostics(
@@ -4341,6 +4664,7 @@ app.post('/admin/events/:id/fight-card/editor', requireAdminSession, async (req,
       eventRecord: eventResponse.data,
       rows: rowsResponse.data,
     });
+    preview.streakVerificationByFighterId = await loadStreakVerificationByFighterId(preview.rows);
     const storedPreview = await replaceFightCardPreview(preview);
     const importedPreview = markFightCardPreviewImported(
       storedPreview.previewToken,
@@ -4395,9 +4719,10 @@ app.get('/admin/events/:id/fight-card/stats', requireAdminSession, async (req, r
       return res.status(500).json({ error: 'Failed to load fight-card stat rows' });
     }
 
+    const decoratedRows = await decorateRowsWithStreakVerification(rows || []);
     return res.json({
       eventId,
-      rows: rows || [],
+      rows: decoratedRows,
       editableFields: ADMIN_FIGHTER_STAT_FIELDS,
     });
   } catch (error) {
@@ -4484,13 +4809,14 @@ app.post('/admin/events/:id/fight-card/stats/:rowId/scrape-tapology', requireAdm
       }
     }
 
-    await persistScrapedTapologyFighterProfile({
+    const profilePersistence = await persistScrapedTapologyFighterProfile({
       row: { ...row, ...fightCardPatch },
       eventId,
       tapologyFighterUrl,
       profile,
       statsSource,
       statsConfidence,
+      verifyLiveStreak: scrapeResult?.diagnostics?.tapology_fetch_status === 'success',
     });
     const updatedFields = Object.keys(patch);
     const scrapeDiagnostics = buildTapologyScrapeDiagnostics(
@@ -4527,6 +4853,7 @@ app.post('/admin/events/:id/fight-card/stats/:rowId/scrape-tapology', requireAdm
       updatedFields,
       scrapeDiagnostics,
       profile,
+      streakVerification: profilePersistence.streakVerification,
     });
   } catch (error) {
     console.error('Error scraping Tapology fighter stats:', error);
@@ -4547,6 +4874,79 @@ app.post('/admin/events/:id/fight-card/stats/:rowId/scrape-tapology', requireAdm
       error: 'Failed to scrape Tapology fighter stats',
       details: error.message,
       scrapeDiagnostics,
+    });
+  }
+});
+
+app.post('/admin/events/:id/fight-card/stats/:rowId/verify-streak', requireAdminSession, async (req, res) => {
+  res.set('Cache-Control', 'no-store');
+
+  try {
+    const eventId = Number(req.params.id);
+    const rowId = Number(req.params.rowId);
+    const normalizedStreak = normalizeAdminStatValue('Streak', req.body?.streak);
+    if (Number.isNaN(eventId) || Number.isNaN(rowId)) {
+      return res.status(400).json({ error: 'Invalid event id or row id' });
+    }
+    if (!normalizedStreak.ok || normalizedStreak.value === null) {
+      return res.status(400).json({ error: normalizedStreak.error || 'Enter a streak before verifying it' });
+    }
+
+    const { data: row, error: rowError } = await supabase
+      .from('ufc_full_fight_card')
+      .select(FIGHT_CARD_STAT_SELECT)
+      .eq('EventId', eventId)
+      .eq('id', rowId)
+      .maybeSingle();
+    if (rowError) {
+      throw new Error(`Failed to load fight-card row: ${rowError.message}`);
+    }
+    if (!row) {
+      return res.status(404).json({ error: `Fight-card row ${rowId} was not found for event ${eventId}` });
+    }
+
+    if (normalizeFiniteInteger(row.Streak) !== normalizedStreak.value) {
+      const { error: updateError } = await supabase
+        .from('ufc_full_fight_card')
+        .update({ Streak: normalizedStreak.value })
+        .eq('EventId', eventId)
+        .eq('id', rowId);
+      if (updateError) {
+        throw new Error(`Failed to update fight-card streak: ${updateError.message}`);
+      }
+    }
+
+    const streakVerification = await persistVerifiedStreakAnchor({
+      row: { ...row, Streak: normalizedStreak.value },
+      eventId,
+      streak: normalizedStreak.value,
+      source: 'manual',
+    });
+    await logAdminAction(req, {
+      action: 'fight_card.verify_streak',
+      status: 'success',
+      targetType: 'event',
+      targetId: eventId,
+      eventId,
+      metadata: {
+        rowId,
+        fighterId: row.FighterId,
+        streak: normalizedStreak.value,
+      },
+    });
+
+    return res.json({
+      eventId,
+      rowId,
+      fighterId: row.FighterId,
+      streak: normalizedStreak.value,
+      streakVerification,
+    });
+  } catch (error) {
+    console.error('Error verifying fighter streak:', error);
+    return res.status(500).json({
+      error: 'Failed to verify fighter streak',
+      details: error.message,
     });
   }
 });
@@ -4619,8 +5019,8 @@ app.post('/admin/events/:id/fight-card/stats', requireAdminSession, async (req, 
     }
 
     let updatedFightCardRows = 0;
+    let verifiedStreakCount = 0;
     const fighterProfilePayloadById = new Map();
-    const nowIso = new Date().toISOString();
 
     for (const update of normalizedUpdates) {
       const { error: updateError } = await supabase
@@ -4635,6 +5035,16 @@ app.post('/admin/events/:id/fight-card/stats', requireAdminSession, async (req, 
 
       updatedFightCardRows += 1;
 
+      if (Object.prototype.hasOwnProperty.call(update.patch, 'Streak') && update.patch.Streak !== null) {
+        await persistVerifiedStreakAnchor({
+          row: { ...update.existingRow, Streak: update.patch.Streak },
+          eventId,
+          streak: update.patch.Streak,
+          source: 'manual',
+        });
+        verifiedStreakCount += 1;
+      }
+
       const fighterId = Number(update.existingRow.FighterId);
       if (!Number.isFinite(fighterId)) {
         continue;
@@ -4642,7 +5052,7 @@ app.post('/admin/events/:id/fight-card/stats', requireAdminSession, async (req, 
 
       const fighterProfileEntries = Object.entries(update.patch)
         .map(([field, value]) => [toFighterProfileColumn(field), field, value])
-        .filter(([profileColumn]) => Boolean(profileColumn));
+        .filter(([profileColumn, field]) => Boolean(profileColumn) && field !== 'Streak');
       if (fighterProfileEntries.length === 0) {
         continue;
       }
@@ -4660,17 +5070,8 @@ app.post('/admin/events/:id/fight-card/stats', requireAdminSession, async (req, 
           .replace(/\s+/g, ' ') || null,
       };
 
-      for (const [profileColumn, field, value] of fighterProfileEntries) {
+      for (const [profileColumn, , value] of fighterProfileEntries) {
         payload[profileColumn] = value;
-        if (field === 'Streak') {
-          payload.stats_source = 'manual_streak';
-          payload.stats_confidence = 'manual_streak';
-          payload.stats_as_of_event_id = eventId;
-          payload.stats_as_of_event_date = typeof update.existingRow.StartTime === 'string'
-            ? update.existingRow.StartTime.split('T')[0]
-            : null;
-          payload.last_success_at = nowIso;
-        }
       }
 
       fighterProfilePayloadById.set(fighterId, payload);
@@ -4698,6 +5099,7 @@ app.post('/admin/events/:id/fight-card/stats', requireAdminSession, async (req, 
         updatedFightCardRows,
         updatedFighters: fighterProfilePayloads.length,
         requestedUpdates: updates.length,
+        verifiedStreakCount,
       },
     });
 
@@ -4705,6 +5107,7 @@ app.post('/admin/events/:id/fight-card/stats', requireAdminSession, async (req, 
       eventId,
       updatedFightCardRows,
       updatedFighters: fighterProfilePayloads.length,
+      verifiedStreakCount,
     });
   } catch (error) {
     console.error('Error updating fight-card stats:', error);
@@ -4803,6 +5206,15 @@ app.post('/admin/events/:id/fight-card/import', requireAdminSession, async (req,
       supabase,
       fightCardRows: preview.rows,
     });
+    const verifiedStreaks = await persistManualStreakAnchors({
+      eventId,
+      preview,
+      manualRowUpdates,
+    });
+    preview.streakVerificationByFighterId = {
+      ...(preview.streakVerificationByFighterId || {}),
+      ...verifiedStreaks,
+    };
 
     const importedPreview = markFightCardPreviewImported(previewToken, eventId, preview);
     if (!importedPreview) {
@@ -4826,6 +5238,7 @@ app.post('/admin/events/:id/fight-card/import', requireAdminSession, async (req,
         warnings: preview.warnings,
         fighter_style_sync: fighterStyleSync,
         applied_manual_update_count: appliedManualUpdateCount,
+        verified_streak_count: Object.keys(verifiedStreaks).length,
         editor_retained: true,
       },
     });
@@ -4839,6 +5252,7 @@ app.post('/admin/events/:id/fight-card/import', requireAdminSession, async (req,
       eventImageUpdate,
       fighterStyleSync,
       appliedManualUpdateCount,
+      verifiedStreakCount: Object.keys(verifiedStreaks).length,
       fightCardPreview,
     });
   } catch (error) {

--- a/Server/lib/fighterStreaks.js
+++ b/Server/lib/fighterStreaks.js
@@ -1,0 +1,176 @@
+const VERIFIED_STREAK_SOURCES = new Set(['manual', 'tapology_live', 'fight_results']);
+const ANCHOR_STREAK_SOURCES = new Set(['manual', 'tapology_live']);
+
+function normalizeInteger(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  if (!/^-?\d+$/.test(normalized)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeRecordInteger(value) {
+  const parsed = normalizeInteger(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function toDateOnly(value) {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = String(value).trim().split('T')[0];
+  return /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : null;
+}
+
+function previousDate(value) {
+  const dateOnly = toDateOnly(value);
+  if (!dateOnly) {
+    return null;
+  }
+
+  const date = new Date(`${dateOnly}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().split('T')[0];
+}
+
+function nextStreak(currentStreak, outcome) {
+  const baseline = Number.isFinite(currentStreak) ? currentStreak : 0;
+  if (outcome === 'win') {
+    return baseline > 0 ? baseline + 1 : 1;
+  }
+  if (outcome === 'loss') {
+    return baseline < 0 ? baseline - 1 : -1;
+  }
+  return baseline;
+}
+
+function isVerifiedStreakProfile(profile) {
+  const source = String(profile?.streak_source || '').trim().toLowerCase();
+  return VERIFIED_STREAK_SOURCES.has(source)
+    && Boolean(profile?.streak_verified_at)
+    && profile?.streak_needs_review !== true
+    && Number.isFinite(normalizeInteger(profile?.streak));
+}
+
+function buildStreakAnchorPayload({
+  row,
+  streak,
+  source,
+  eventId,
+  eventDate,
+  fightCompleted = false,
+  verifiedAt = new Date().toISOString(),
+}) {
+  const normalizedSource = String(source || '').trim().toLowerCase();
+  if (!ANCHOR_STREAK_SOURCES.has(normalizedSource)) {
+    throw new Error(`Unsupported streak anchor source: ${source}`);
+  }
+
+  const normalizedStreak = normalizeInteger(streak);
+  if (!Number.isFinite(normalizedStreak)) {
+    throw new Error('Streak must be a signed whole number');
+  }
+
+  const normalizedEventDate = toDateOnly(eventDate || row?.StartTime);
+  const throughDate = fightCompleted
+    ? normalizedEventDate
+    : previousDate(normalizedEventDate);
+  const recordWins = normalizeRecordInteger(row?.Record_Wins);
+  const recordLosses = normalizeRecordInteger(row?.Record_Losses);
+
+  return {
+    streak: normalizedStreak,
+    streak_source: normalizedSource,
+    streak_anchor_source: normalizedSource,
+    streak_verified_at: verifiedAt,
+    streak_anchor_value: normalizedStreak,
+    streak_anchor_record_wins: recordWins,
+    streak_anchor_record_losses: recordLosses,
+    streak_anchor_event_id: Number.isFinite(Number(eventId)) ? Number(eventId) : null,
+    streak_anchor_through_date: throughDate,
+    streak_record_wins: recordWins,
+    streak_record_losses: recordLosses,
+    streak_verified_through_date: throughDate,
+    streak_needs_review: false,
+  };
+}
+
+function replayStreakFromAnchor(profile, resultRows) {
+  const anchorValue = normalizeInteger(profile?.streak_anchor_value);
+  if (!Number.isFinite(anchorValue) || !profile?.streak_verified_at) {
+    return { ok: false, reason: 'No verified streak anchor' };
+  }
+
+  const anchorThroughDate = toDateOnly(profile.streak_anchor_through_date);
+  const orderedRows = [...(resultRows || [])]
+    .filter((row) => {
+      const eventDate = toDateOnly(row?.event_date);
+      return eventDate && (!anchorThroughDate || eventDate > anchorThroughDate);
+    })
+    .sort((left, right) => (
+      String(left.event_date).localeCompare(String(right.event_date))
+      || Number(left.event_id) - Number(right.event_id)
+      || Number(left.fight_id) - Number(right.fight_id)
+    ));
+
+  let streak = anchorValue;
+  let recordWins = normalizeRecordInteger(profile.streak_anchor_record_wins);
+  let recordLosses = normalizeRecordInteger(profile.streak_anchor_record_losses);
+  let verifiedThroughDate = anchorThroughDate;
+
+  for (const row of orderedRows) {
+    if (!['win', 'loss'].includes(row.outcome)) {
+      continue;
+    }
+
+    streak = nextStreak(streak, row.outcome);
+    if (row.outcome === 'win' && recordWins !== null) {
+      recordWins += 1;
+    }
+    if (row.outcome === 'loss' && recordLosses !== null) {
+      recordLosses += 1;
+    }
+    verifiedThroughDate = toDateOnly(row.event_date) || verifiedThroughDate;
+  }
+
+  return {
+    ok: true,
+    streak,
+    recordWins,
+    recordLosses,
+    verifiedThroughDate,
+    appliedResultCount: orderedRows.length,
+  };
+}
+
+function streakRecordMatches(profile, recordWins, recordLosses) {
+  const expectedWins = normalizeRecordInteger(profile?.streak_record_wins);
+  const expectedLosses = normalizeRecordInteger(profile?.streak_record_losses);
+  const actualWins = normalizeRecordInteger(recordWins);
+  const actualLosses = normalizeRecordInteger(recordLosses);
+
+  if ([expectedWins, expectedLosses, actualWins, actualLosses].some((value) => value === null)) {
+    return null;
+  }
+
+  return expectedWins === actualWins && expectedLosses === actualLosses;
+}
+
+module.exports = {
+  ANCHOR_STREAK_SOURCES,
+  VERIFIED_STREAK_SOURCES,
+  buildStreakAnchorPayload,
+  isVerifiedStreakProfile,
+  nextStreak,
+  normalizeInteger,
+  replayStreakFromAnchor,
+  streakRecordMatches,
+  toDateOnly,
+};

--- a/Server/scraper/scrape_full_ufc_event_with_tapology.py
+++ b/Server/scraper/scrape_full_ufc_event_with_tapology.py
@@ -44,7 +44,8 @@ SUPABASE_FIGHTER_PROFILE_SELECT = (
     "fighter_id,mma_id,first_name,last_name,normalized_name,tapology_fighter_url,"
     "rank,streak,style,ko_tko_wins,ko_tko_losses,submission_wins,"
     "submission_losses,decision_wins,decision_losses,stats_confidence,"
-    "stats_source,last_success_at,last_failure_at,last_error"
+    "stats_source,streak_source,streak_verified_at,streak_needs_review,"
+    "streak_record_wins,streak_record_losses,last_success_at,last_failure_at,last_error"
 )
 SUPABASE_TAPOLOGY_EVENT_SELECT = (
     "event_id,event_name,event_date,tapology_event_url,event_image_url,"
@@ -64,16 +65,7 @@ DEFAULT_TAPOLOGY_MAP = os.path.join(SCRIPT_DIR, "tapology_event_map.csv")
 DEFAULT_TAPOLOGY_CACHE_DIR = os.path.join(SCRIPT_DIR, "tapology_cache")
 DEFAULT_TAPOLOGY_DELAY_SECONDS = 1.25
 DEFAULT_TAPOLOGY_PREVIEW_PROFILE_LIMIT = 4
-CURRENT_STREAK_SOURCES = {
-    "cached_profile_url",
-    "fight_result",
-    "live_profile",
-    "manual_streak",
-    "tapology_partial_profile",
-    "tapology_single_profile",
-    "tapology_wikipedia_merged",
-    "wikipedia_record_breakdown",
-}
+CURRENT_STREAK_SOURCES = {"manual", "tapology_live", "fight_results"}
 TAPOLOGY_ENRICHMENT_FIELDS = [
     "TapologyFighterURL",
     "TapologyMatchConfidence",
@@ -445,8 +437,10 @@ def cache_confidence(value: object, prefix: str = "cache") -> str:
 
 
 def cached_streak_is_current(row: Dict[str, object]) -> bool:
-    source = cache_value_to_csv(row.get("stats_source") or row.get("source")).lower()
-    return source in CURRENT_STREAK_SOURCES
+    source = cache_value_to_csv(row.get("streak_source")).lower()
+    verified_at = cache_value_to_csv(row.get("streak_verified_at"))
+    needs_review = row.get("streak_needs_review") is True
+    return source in CURRENT_STREAK_SOURCES and bool(verified_at) and not needs_review
 
 
 def normalize_tapology_cache_fighter(row: Dict[str, object]) -> Dict[str, str]:
@@ -608,7 +602,27 @@ def tapology_cache_fighter_for_fighter(
     if cache_row is None and fighter_name:
         cache_row = tapology_cache_lookup.get("fighters_by_name", {}).get(fighter_name)
 
-    return normalize_tapology_cache_fighter(cache_row) if cache_row else {}
+    if not cache_row:
+        return {}
+
+    normalized = normalize_tapology_cache_fighter(cache_row)
+    if normalized.get("Streak"):
+        record = fighter.get("Record", {}) or {}
+        actual_wins = parse_optional_int(record.get("Wins"))
+        actual_losses = parse_optional_int(record.get("Losses"))
+        expected_wins = parse_optional_int(cache_row.get("streak_record_wins"))
+        expected_losses = parse_optional_int(cache_row.get("streak_record_losses"))
+        if (
+            actual_wins is None
+            or actual_losses is None
+            or expected_wins is None
+            or expected_losses is None
+            or actual_wins != expected_wins
+            or actual_losses != expected_losses
+        ):
+            normalized["Streak"] = ""
+
+    return normalized
 
 
 def load_tapology_cache_fighter_enrichment(
@@ -787,9 +801,34 @@ def upsert_tapology_fighter_cache(
         print(f"Tapology fighter cache upsert skipped: {err}")
 
     event_date = str(event.get("StartTime", "")).split("T")[0] or None
+    event_start = parse_start_time(event.get("StartTime"))
+    if event_start and event_start.tzinfo is None:
+        event_start = event_start.replace(tzinfo=datetime.timezone.utc)
+    event_is_upcoming = bool(
+        event_start
+        and event_start > datetime.datetime.now(datetime.timezone.utc)
+    )
+    anchor_through_date = None
+    if event_date and event_is_upcoming:
+        anchor_through_date = (
+            datetime.date.fromisoformat(event_date) - datetime.timedelta(days=1)
+        ).isoformat()
     fighter_profile_payloads = []
+    fighters_by_id = {
+        parse_optional_int(fighter.get("FighterId")): fighter
+        for fight in event.get("FightCard", [])
+        for fighter in fight.get("Fighters", [])
+    }
     for payload in payloads:
-        has_current_streak = payload.get("streak") is not None
+        fighter = fighters_by_id.get(payload.get("fighter_id"), {})
+        record = fighter.get("Record", {}) or {}
+        record_wins = parse_optional_int(record.get("Wins"))
+        record_losses = parse_optional_int(record.get("Losses"))
+        has_current_streak = (
+            payload.get("streak") is not None
+            and event_is_upcoming
+            and source in {"cached_profile_url", "live_profile"}
+        )
         fighter_profile_payload = {
             "fighter_id": payload.get("fighter_id"),
             "mma_id": payload.get("mma_id"),
@@ -798,7 +837,6 @@ def upsert_tapology_fighter_cache(
             "normalized_name": payload.get("normalized_name"),
             "tapology_fighter_url": payload.get("tapology_fighter_url"),
             "rank": payload.get("rank"),
-            "streak": payload.get("streak"),
             "style": payload.get("style"),
             "ko_tko_wins": payload.get("ko_tko_wins"),
             "ko_tko_losses": payload.get("ko_tko_losses"),
@@ -811,6 +849,19 @@ def upsert_tapology_fighter_cache(
         }
         if has_current_streak:
             fighter_profile_payload.update({
+                "streak": payload.get("streak"),
+                "streak_source": "tapology_live",
+                "streak_anchor_source": "tapology_live",
+                "streak_verified_at": payload.get("last_success_at"),
+                "streak_anchor_value": payload.get("streak"),
+                "streak_anchor_record_wins": record_wins,
+                "streak_anchor_record_losses": record_losses,
+                "streak_anchor_event_id": parse_optional_int(event.get("EventId")),
+                "streak_anchor_through_date": anchor_through_date,
+                "streak_record_wins": record_wins,
+                "streak_record_losses": record_losses,
+                "streak_verified_through_date": anchor_through_date,
+                "streak_needs_review": False,
                 "stats_source": source,
                 "stats_confidence": payload.get("match_confidence"),
                 "stats_as_of_event_id": parse_optional_int(event.get("EventId")),

--- a/Server/scraper/test_tapology_cache.py
+++ b/Server/scraper/test_tapology_cache.py
@@ -14,24 +14,48 @@ class TapologyCacheTests(unittest.TestCase):
             "ko_tko_wins": 8,
             "source": "historical_import",
         })
-        current = scraper.normalize_tapology_cache_fighter({
+        verified = scraper.normalize_tapology_cache_fighter({
             "streak": -2,
-            "stats_source": "fight_result",
+            "streak_source": "fight_results",
+            "streak_verified_at": "2026-08-01T00:00:00Z",
+            "streak_needs_review": False,
         })
         ambiguous_manual = scraper.normalize_tapology_cache_fighter({
             "streak": 3,
-            "stats_source": "manual_admin",
+            "streak_source": "manual",
         })
         manual_streak = scraper.normalize_tapology_cache_fighter({
             "streak": 3,
-            "stats_source": "manual_streak",
+            "streak_source": "manual",
+            "streak_verified_at": "2026-08-01T00:00:00Z",
+            "streak_needs_review": False,
         })
 
         self.assertEqual(historical["Streak"], "")
         self.assertEqual(historical["KO_TKO_Wins"], "8")
-        self.assertEqual(current["Streak"], "-2")
+        self.assertEqual(verified["Streak"], "-2")
         self.assertEqual(ambiguous_manual["Streak"], "")
         self.assertEqual(manual_streak["Streak"], "3")
+
+    def test_verified_cached_streak_must_match_the_current_record(self):
+        lookup = scraper.empty_tapology_cache_lookup()
+        lookup["fighters_by_fighter_id"]["10"] = {
+            "fighter_id": 10,
+            "streak": 4,
+            "streak_source": "tapology_live",
+            "streak_verified_at": "2026-08-01T00:00:00Z",
+            "streak_needs_review": False,
+            "streak_record_wins": 12,
+            "streak_record_losses": 2,
+        }
+        fighter = {
+            "FighterId": 10,
+            "Record": {"Wins": 13, "Losses": 2},
+            "Name": {"FirstName": "Test", "LastName": "Fighter"},
+        }
+
+        cached = scraper.tapology_cache_fighter_for_fighter(fighter, lookup)
+        self.assertEqual(cached["Streak"], "")
 
     def test_resolve_style_prefers_fighter_style_over_tapology_cache(self):
         fighter = {
@@ -152,6 +176,46 @@ class TapologyCacheTests(unittest.TestCase):
         self.assertNotIn("stats_source", fighter_payload)
         self.assertNotIn("stats_as_of_event_id", fighter_payload)
         self.assertNotIn("last_success_at", fighter_payload)
+
+    @mock.patch.object(scraper, "upsert_supabase_rows")
+    def test_live_profile_streak_creates_a_verified_upcoming_anchor(self, upsert_rows):
+        upsert_rows.return_value = 1
+        event = {
+            "EventId": 2000,
+            "StartTime": "2099-08-15T22:00:00Z",
+            "FightCard": [{
+                "Fighters": [{
+                    "FighterId": 10,
+                    "MMAId": 20,
+                    "Name": {"FirstName": "Test", "LastName": "Fighter"},
+                    "Record": {"Wins": 12, "Losses": 3},
+                }],
+            }],
+        }
+
+        scraper.upsert_tapology_fighter_cache(
+            event=event,
+            enrichment={
+                "test fighter": {
+                    "TapologyFighterURL": "https://example.com/fighter",
+                    "Streak": "-2",
+                },
+            },
+            timeout=5,
+            source="live_profile",
+        )
+
+        fighters_call = next(
+            call for call in upsert_rows.call_args_list
+            if call.args[0] == "fighters"
+        )
+        fighter_payload = fighters_call.args[1][0]
+        self.assertEqual(fighter_payload["streak"], -2)
+        self.assertEqual(fighter_payload["streak_source"], "tapology_live")
+        self.assertEqual(fighter_payload["streak_anchor_record_wins"], 12)
+        self.assertEqual(fighter_payload["streak_anchor_record_losses"], 3)
+        self.assertEqual(fighter_payload["streak_anchor_through_date"], "2099-08-14")
+        self.assertFalse(fighter_payload["streak_needs_review"])
 
 
 if __name__ == "__main__":

--- a/Server/scraper/test_tapology_fighter_profile.py
+++ b/Server/scraper/test_tapology_fighter_profile.py
@@ -38,9 +38,19 @@ class TapologyFighterProfileTests(unittest.TestCase):
         self.assertEqual(extract_tapology_streak("Current MMA Streak: 3 Wins"), "3")
         self.assertEqual(extract_tapology_streak("Current MMA Streak: 1 Loss"), "-1")
 
-    def test_merged_tapology_streak_is_reusable_on_future_previews(self):
-        self.assertTrue(cached_streak_is_current({"stats_source": "tapology_wikipedia_merged"}))
-        self.assertTrue(cached_streak_is_current({"source": "tapology_partial_profile"}))
+    def test_only_explicitly_verified_streaks_are_reusable_on_future_previews(self):
+        self.assertFalse(cached_streak_is_current({"stats_source": "tapology_wikipedia_merged"}))
+        self.assertFalse(cached_streak_is_current({"source": "tapology_partial_profile"}))
+        self.assertTrue(cached_streak_is_current({
+            "streak_source": "tapology_live",
+            "streak_verified_at": "2026-08-01T00:00:00Z",
+            "streak_needs_review": False,
+        }))
+        self.assertFalse(cached_streak_is_current({
+            "streak_source": "tapology_live",
+            "streak_verified_at": "2026-08-01T00:00:00Z",
+            "streak_needs_review": True,
+        }))
 
 
 if __name__ == "__main__":

--- a/Server/test/fighterStreaks.test.js
+++ b/Server/test/fighterStreaks.test.js
@@ -1,0 +1,90 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  buildStreakAnchorPayload,
+  isVerifiedStreakProfile,
+  replayStreakFromAnchor,
+  streakRecordMatches,
+} = require('../lib/fighterStreaks');
+
+test('legacy cached streaks are not treated as verified', () => {
+  assert.equal(isVerifiedStreakProfile({
+    streak: 4,
+    stats_source: 'cached_profile_url',
+    streak_needs_review: false,
+  }), false);
+});
+
+test('manual verification creates a pre-event streak anchor', () => {
+  const payload = buildStreakAnchorPayload({
+    row: {
+      Record_Wins: 12,
+      Record_Losses: 3,
+      StartTime: '2026-08-15T22:00:00Z',
+    },
+    streak: '-2',
+    source: 'manual',
+    eventId: 1325,
+    verifiedAt: '2026-08-14T12:00:00Z',
+  });
+
+  assert.equal(payload.streak, -2);
+  assert.equal(payload.streak_source, 'manual');
+  assert.equal(payload.streak_anchor_value, -2);
+  assert.equal(payload.streak_anchor_record_wins, 12);
+  assert.equal(payload.streak_anchor_record_losses, 3);
+  assert.equal(payload.streak_anchor_through_date, '2026-08-14');
+  assert.equal(payload.streak_needs_review, false);
+  assert.equal(isVerifiedStreakProfile(payload), true);
+});
+
+test('completed-event verification excludes that event from future replay', () => {
+  const payload = buildStreakAnchorPayload({
+    row: {
+      Record_Wins: 13,
+      Record_Losses: 3,
+      StartTime: '2026-08-15T22:00:00Z',
+    },
+    streak: 1,
+    source: 'tapology_live',
+    eventId: 1325,
+    fightCompleted: true,
+    verifiedAt: '2026-08-16T12:00:00Z',
+  });
+
+  assert.equal(payload.streak_anchor_through_date, '2026-08-15');
+  assert.equal(payload.streak_source, 'tapology_live');
+});
+
+test('result replay is chronological and idempotent from the anchor', () => {
+  const profile = buildStreakAnchorPayload({
+    row: { Record_Wins: 10, Record_Losses: 2, StartTime: '2026-08-15' },
+    streak: 3,
+    source: 'manual',
+    eventId: 1325,
+    verifiedAt: '2026-08-14T12:00:00Z',
+  });
+  const results = [
+    { fight_id: 2, event_id: 1326, event_date: '2026-09-01', outcome: 'win' },
+    { fight_id: 1, event_id: 1325, event_date: '2026-08-15', outcome: 'loss' },
+  ];
+
+  const first = replayStreakFromAnchor(profile, results);
+  const second = replayStreakFromAnchor(profile, results);
+  assert.deepEqual(first, second);
+  assert.equal(first.streak, 1);
+  assert.equal(first.recordWins, 11);
+  assert.equal(first.recordLosses, 3);
+  assert.equal(first.appliedResultCount, 2);
+});
+
+test('record validation detects an external or missing fight', () => {
+  const profile = {
+    streak_record_wins: 15,
+    streak_record_losses: 4,
+  };
+
+  assert.equal(streakRecordMatches(profile, 15, 4), true);
+  assert.equal(streakRecordMatches(profile, 16, 4), false);
+  assert.equal(streakRecordMatches(profile, null, 4), null);
+});

--- a/supabase/migrations/20260807183417_verified_fighter_streak_anchors.sql
+++ b/supabase/migrations/20260807183417_verified_fighter_streak_anchors.sql
@@ -1,0 +1,87 @@
+ALTER TABLE public.fighters
+  ADD COLUMN IF NOT EXISTS streak_source text,
+  ADD COLUMN IF NOT EXISTS streak_anchor_source text,
+  ADD COLUMN IF NOT EXISTS streak_verified_at timestamptz,
+  ADD COLUMN IF NOT EXISTS streak_anchor_value integer,
+  ADD COLUMN IF NOT EXISTS streak_anchor_record_wins integer,
+  ADD COLUMN IF NOT EXISTS streak_anchor_record_losses integer,
+  ADD COLUMN IF NOT EXISTS streak_anchor_event_id bigint,
+  ADD COLUMN IF NOT EXISTS streak_anchor_through_date date,
+  ADD COLUMN IF NOT EXISTS streak_record_wins integer,
+  ADD COLUMN IF NOT EXISTS streak_record_losses integer,
+  ADD COLUMN IF NOT EXISTS streak_verified_through_date date,
+  ADD COLUMN IF NOT EXISTS streak_needs_review boolean NOT NULL DEFAULT true;
+
+ALTER TABLE public.fighters
+  DROP CONSTRAINT IF EXISTS fighters_streak_source_check,
+  ADD CONSTRAINT fighters_streak_source_check
+    CHECK (streak_source IS NULL OR streak_source IN ('manual', 'tapology_live', 'fight_results')),
+  DROP CONSTRAINT IF EXISTS fighters_streak_anchor_source_check,
+  ADD CONSTRAINT fighters_streak_anchor_source_check
+    CHECK (streak_anchor_source IS NULL OR streak_anchor_source IN ('manual', 'tapology_live')),
+  DROP CONSTRAINT IF EXISTS fighters_streak_anchor_record_wins_check,
+  ADD CONSTRAINT fighters_streak_anchor_record_wins_check
+    CHECK (streak_anchor_record_wins IS NULL OR streak_anchor_record_wins >= 0),
+  DROP CONSTRAINT IF EXISTS fighters_streak_anchor_record_losses_check,
+  ADD CONSTRAINT fighters_streak_anchor_record_losses_check
+    CHECK (streak_anchor_record_losses IS NULL OR streak_anchor_record_losses >= 0),
+  DROP CONSTRAINT IF EXISTS fighters_streak_record_wins_check,
+  ADD CONSTRAINT fighters_streak_record_wins_check
+    CHECK (streak_record_wins IS NULL OR streak_record_wins >= 0),
+  DROP CONSTRAINT IF EXISTS fighters_streak_record_losses_check,
+  ADD CONSTRAINT fighters_streak_record_losses_check
+    CHECK (streak_record_losses IS NULL OR streak_record_losses >= 0);
+
+-- Every pre-migration streak has mixed or incomplete provenance. Keep the value for
+-- historical inspection, but require a new live Tapology or manual anchor before use.
+UPDATE public.fighters
+SET
+  streak_source = NULL,
+  streak_anchor_source = NULL,
+  streak_verified_at = NULL,
+  streak_anchor_value = NULL,
+  streak_anchor_record_wins = NULL,
+  streak_anchor_record_losses = NULL,
+  streak_anchor_event_id = NULL,
+  streak_anchor_through_date = NULL,
+  streak_record_wins = NULL,
+  streak_record_losses = NULL,
+  streak_verified_through_date = NULL,
+  streak_needs_review = true;
+
+CREATE TABLE IF NOT EXISTS public.fighter_streak_results (
+  fighter_id bigint NOT NULL,
+  fight_id bigint NOT NULL,
+  event_id bigint NOT NULL,
+  event_date date NOT NULL,
+  outcome text NOT NULL CHECK (outcome IN ('win', 'loss')),
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  PRIMARY KEY (fighter_id, fight_id)
+);
+
+CREATE INDEX IF NOT EXISTS fighter_streak_results_replay_idx
+ON public.fighter_streak_results (fighter_id, event_date, event_id, fight_id);
+
+CREATE OR REPLACE FUNCTION public.set_fighter_streak_results_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = timezone('utc', now());
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_fighter_streak_results_updated_at
+ON public.fighter_streak_results;
+CREATE TRIGGER set_fighter_streak_results_updated_at
+BEFORE UPDATE ON public.fighter_streak_results
+FOR EACH ROW
+EXECUTE FUNCTION public.set_fighter_streak_results_updated_at();
+
+ALTER TABLE public.fighter_streak_results ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.fighter_streak_results FROM anon, authenticated;
+GRANT ALL ON TABLE public.fighter_streak_results TO service_role;


### PR DESCRIPTION
- Add fighter streak management logic in fighterStreaks.js, including functions for normalizing integers, building streak anchor payloads, and replaying streaks from anchors.
- Update scrape_full_ufc_event_with_tapology.py to include new streak-related fields in fighter profiles and adjust logic for current streak verification.
- Enhance test coverage for streak functionalities in test_tapology_cache.py and test_tapology_fighter_profile.py, ensuring proper verification and replay of streaks.
- Create a new SQL migration to add streak-related columns to the fighters table and establish a new fighter_streak_results table for tracking fight outcomes.