### PR TITLE
feat: add result type for fight outcomes and update related logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.19.0 - 2026-08-21
+
+### Added
+
+- Added Draw and No Contest fight outcomes to the admin result controls and fight-card result display.
+
+### Changed
+
+- Made Draw and No Contest complete a fight while awarding every submitted pick zero points and leaving both fighters without a win or loss result.
+
 ## 0.18.4 - 2026-08-21
 
 ### Fixed

--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.18.4",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.18.4",
+      "version": "0.19.0",
       "dependencies": {
         "esbuild": "^0.25.1",
         "lucide-react": "1.26.0",

--- a/Client/package.json
+++ b/Client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.18.4",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/Client/src/Fights.css
+++ b/Client/src/Fights.css
@@ -716,7 +716,7 @@ button.submit-vote-button:focus-visible {
 }
 
 .fight-card.completed::before {
-  content: 'FIGHT COMPLETED';
+  content: attr(data-result-label);
   position: absolute;
   top: 0;
   left: 50%;
@@ -741,6 +741,14 @@ button.submit-vote-button:focus-visible {
   filter: grayscale(70%);
   border: 1px solid rgba(128, 128, 128, 0.2);
   background: linear-gradient(145deg, rgba(11, 17, 32, 0.72), rgba(17, 24, 39, 0.72));
+}
+
+.fighter-card.neutral-result {
+  cursor: not-allowed;
+  opacity: 1;
+  filter: none;
+  border-color: rgba(252, 251, 253, 0.32);
+  background: rgba(252, 251, 253, 0.05);
 }
 
 /* Vote badge styles */
@@ -1889,6 +1897,10 @@ button.admin-edit-button:hover {
 .admin-buttons {
   display: flex;
   gap: 12px;
+}
+
+.admin-neutral-result-buttons {
+  margin-top: -4px;
 }
 
 button.admin-winner-button {

--- a/Client/src/Fights.jsx
+++ b/Client/src/Fights.jsx
@@ -18,6 +18,10 @@ import VoteCard from './components/VoteCard';
 const REMINDER_TYPE_BROKEN_HEART = 'broken_heart';
 const REMINDER_TYPE_HEART_EYES = 'heart_eyes';
 const FIGHT_CARD_REFRESH_INTERVAL_MS = 15000;
+const RESULT_TYPE_LABELS = {
+  draw: 'Draw',
+  no_contest: 'No Contest',
+};
 const REMINDER_EMOJI_MAP = {
   [REMINDER_TYPE_BROKEN_HEART]: '💔',
   [REMINDER_TYPE_HEART_EYES]: '😍'
@@ -585,14 +589,14 @@ function Fights({
   };
 
   // Admin function to handle fight result updates
-  const handleResultUpdate = async (fightId, winner) => {
+  const handleResultUpdate = async (fightId, winner, resultType = winner ? 'winner' : null) => {
     try {
       const response = await fetchWithAdminSession(`${API_URL}/ufc_full_fight_card/${fightId}/result`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ winner }),
+        body: JSON.stringify({ winner, result_type: resultType }),
       });
 
       if (!response.ok) {
@@ -614,6 +618,10 @@ function Fights({
           mergedFight[key] = val;
         }
       });
+      // Null is meaningful for draws, no contests, and cleared results.
+      mergedFight.winner = updatedFight.winner ?? null;
+      mergedFight.result_type = updatedFight.result_type ?? null;
+      mergedFight.is_completed = Boolean(updatedFight.is_completed);
 
       setFights(fights.map(fight => 
         fight.id === fightId ? mergedFight : fight
@@ -1372,11 +1380,13 @@ function Fights({
           const fightFormatDetails = getFightFormatDetails(fight);
           const hasFightMeta = fight.card_tier || fight.weightclass || fight.is_canceled || fightFormatDetails;
           const fightCardClassName = `fight-card ${fight.is_completed ? 'completed' : ''} ${fight.is_canceled ? 'canceled' : ''} ${fight.is_title_fight ? 'title-fight' : ''}`.trim();
+          const neutralResultLabel = RESULT_TYPE_LABELS[fight.result_type] || null;
 
           return (
         <div
           key={fight.id}
           className={fightCardClassName}
+          data-result-label={neutralResultLabel || (fight.is_completed ? 'Fight Completed' : undefined)}
           data-fight-id={fight.id}
           ref={(node) => {
             const fightKey = String(fight.id);
@@ -1435,9 +1445,11 @@ function Fights({
             <div
               className={`fighter-card ${
                 fight.is_completed
-                  ? String(fight.winner) === String(fight.fighter1_id)
-                    ? 'winner'
-                    : 'loser'
+                  ? fight.winner
+                    ? String(fight.winner) === String(fight.fighter1_id)
+                      ? 'winner'
+                      : 'loser'
+                    : 'neutral-result'
                   : (selectedFights[fight.id] === fight.fighter1_id || submittedFights[fight.id] === fight.fighter1_id)
                     ? 'selected'
                     : (submittedFights[fight.id] && submittedFights[fight.id] !== fight.fighter1_id)
@@ -1591,9 +1603,11 @@ function Fights({
             <div
               className={`fighter-card ${
                 fight.is_completed
-                  ? String(fight.winner) === String(fight.fighter2_id)
-                    ? 'winner'
-                    : 'loser'
+                  ? fight.winner
+                    ? String(fight.winner) === String(fight.fighter2_id)
+                      ? 'winner'
+                      : 'loser'
+                    : 'neutral-result'
                   : (selectedFights[fight.id] === fight.fighter2_id || submittedFights[fight.id] === fight.fighter2_id)
                     ? 'selected'
                     : (submittedFights[fight.id] && submittedFights[fight.id] !== fight.fighter2_id)
@@ -1910,10 +1924,12 @@ function Fights({
                     <div className="admin-canceled-display">
                       <span className="canceled-text">Fight Canceled</span>
                     </div>
-                  ) : fight.winner && editingFight !== fight.id ? (
+                  ) : fight.is_completed && editingFight !== fight.id ? (
                     <div className="admin-result-display">
                       <span className="winner-text">
-                        Winner: {String(fight.winner) === String(fight.fighter1_id) ? fight.fighter1_name : fight.fighter2_name}
+                        {fight.winner
+                          ? `Winner: ${String(fight.winner) === String(fight.fighter1_id) ? fight.fighter1_name : fight.fighter2_name}`
+                          : RESULT_TYPE_LABELS[fight.result_type] || 'Completed'}
                       </span>
                       <div className="admin-action-buttons">
                         <button 
@@ -1930,29 +1946,43 @@ function Fights({
                         </button>
                       </div>
                     </div>
-                  ) : (editingFight === fight.id || !fight.winner) && (
+                  ) : (editingFight === fight.id || !fight.is_completed) && (
                     <div className="admin-result-editor">
                       <div className="admin-buttons">
                         <button
                           className={`admin-winner-button ${String(fight.winner) === String(fight.fighter1_id) ? 'selected' : ''}`}
-                          onClick={() => handleResultUpdate(fight.id, fight.fighter1_id)}
+                          onClick={() => handleResultUpdate(fight.id, fight.fighter1_id, 'winner')}
                         >
                           {fight.fighter1_name} Won
                         </button>
                         <button
                           className={`admin-winner-button ${String(fight.winner) === String(fight.fighter2_id) ? 'selected' : ''}`}
-                          onClick={() => handleResultUpdate(fight.id, fight.fighter2_id)}
+                          onClick={() => handleResultUpdate(fight.id, fight.fighter2_id, 'winner')}
                         >
                           {fight.fighter2_name} Won
                         </button>
                       </div>
+                      <div className="admin-buttons admin-neutral-result-buttons">
+                        <button
+                          className={`admin-winner-button ${fight.result_type === 'draw' ? 'selected' : ''}`}
+                          onClick={() => handleResultUpdate(fight.id, null, 'draw')}
+                        >
+                          Draw
+                        </button>
+                        <button
+                          className={`admin-winner-button ${fight.result_type === 'no_contest' ? 'selected' : ''}`}
+                          onClick={() => handleResultUpdate(fight.id, null, 'no_contest')}
+                        >
+                          No Contest
+                        </button>
+                      </div>
                       <div className="admin-action-buttons">
-                        {fight.winner && (
+                        {fight.is_completed && (
                           <button
                             className="admin-unselect-button"
-                            onClick={() => handleResultUpdate(fight.id, null)}
+                            onClick={() => handleResultUpdate(fight.id, null, null)}
                           >
-                            Unselect Winner
+                            Clear Result
                           </button>
                         )}
                         <button 

--- a/Client/src/components/EventFriendComparison.jsx
+++ b/Client/src/components/EventFriendComparison.jsx
@@ -14,6 +14,12 @@ function getFightStateCopy(fight, friendName) {
   if (fight.comparison_state === 'canceled') {
     return { label: 'Canceled', detail: 'No sweat' };
   }
+  if (fight.is_completed && fight.result_type === 'draw') {
+    return { label: 'Draw', detail: 'No points' };
+  }
+  if (fight.is_completed && fight.result_type === 'no_contest') {
+    return { label: 'No contest', detail: 'No points' };
+  }
   if (fight.comparison_state === 'agreement') {
     if (!fight.is_completed) return { label: 'Agree', detail: 'Same side' };
     if (fight.viewer_pick?.is_correct) return { label: 'Agree', detail: 'Both hit' };

--- a/Client/src/utils/pollingPolicy.js
+++ b/Client/src/utils/pollingPolicy.js
@@ -18,6 +18,7 @@ function normalizeFightCardForComparison(fights) {
     fighter1_id: fight?.fighter1_id == null ? null : String(fight.fighter1_id),
     fighter2_id: fight?.fighter2_id == null ? null : String(fight.fighter2_id),
     winner: fight?.winner == null ? null : String(fight.winner),
+    result_type: fight?.result_type || null,
   }));
 }
 
@@ -30,6 +31,7 @@ export function haveFightResultsChanged(currentFights, incomingFights) {
   const resultState = (fights) => (Array.isArray(fights) ? fights : []).map((fight) => ({
     id: String(fight?.id ?? ''),
     winner: fight?.winner == null ? null : String(fight.winner),
+    result_type: fight?.result_type || null,
     is_completed: Boolean(fight?.is_completed),
     is_canceled: Boolean(fight?.is_canceled),
   }));

--- a/Client/test/pollingPolicy.test.js
+++ b/Client/test/pollingPolicy.test.js
@@ -39,4 +39,8 @@ test('detects completed, canceled, and corrected fight results', () => {
   assert.equal(haveFightResultsChanged(current, completed), true);
   assert.equal(haveFightResultsChanged(completed, equivalent), false);
   assert.equal(haveFightResultsChanged(completed, corrected), true);
+  assert.equal(haveFightResultsChanged(
+    [{ id: 10, winner: null, result_type: 'draw', is_completed: true, is_canceled: false }],
+    [{ id: 10, winner: null, result_type: 'no_contest', is_completed: true, is_canceled: false }]
+  ), true);
 });

--- a/Server/index.js
+++ b/Server/index.js
@@ -52,6 +52,7 @@ const {
   addFightToFightRankChanges,
   findLatestCompletedFightId,
 } = require('./lib/eventLeaderboardDeltas');
+const { scorePredictionOutcome } = require('./lib/predictionScoring');
 const {
   runUfcEventDiscovery,
 } = require('./lib/ufcEventDiscovery');
@@ -730,7 +731,7 @@ async function loadStreakVerificationByFighterId(rows) {
     fightIds.length > 0
       ? supabase
           .from('fight_results')
-          .select('fight_id,fighter_id,is_completed')
+          .select('fight_id,fighter_id,is_completed,result_type')
           .in('fight_id', fightIds)
       : Promise.resolve({ data: [], error: null }),
   ]);
@@ -752,7 +753,9 @@ async function loadStreakVerificationByFighterId(rows) {
     );
     const result = resultsByFightId.get(Number(row?.FightId ?? row?.fightId));
     let comparisonRow = row;
-    if (result?.is_completed === true && row) {
+    const hasWinnerResult = result?.is_completed === true
+      && (result.result_type === 'winner' || (!result.result_type && result.fighter_id != null));
+    if (hasWinnerResult && row) {
       const won = Number(result.fighter_id) === fighterId;
       const wins = normalizeFiniteInteger(row.Record_Wins);
       const losses = normalizeFiniteInteger(row.Record_Losses);
@@ -794,14 +797,16 @@ async function persistVerifiedStreakAnchor({ row, eventId, streak, source }) {
   if (Number.isFinite(fightId)) {
     const { data: result, error: resultError } = await supabase
       .from('fight_results')
-      .select('fighter_id,is_completed')
+      .select('fighter_id,is_completed,result_type')
       .eq('fight_id', fightId)
       .maybeSingle();
     if (resultError) {
       throw new Error(`Failed to check the fight result before verifying streak: ${resultError.message}`);
     }
     fightCompleted = result?.is_completed === true;
-    if (fightCompleted) {
+    const hasWinnerResult = fightCompleted
+      && (result.result_type === 'winner' || (!result.result_type && result.fighter_id != null));
+    if (hasWinnerResult) {
       const won = Number(result.fighter_id) === fighterId;
       const recordWins = normalizeFiniteInteger(row?.Record_Wins);
       const recordLosses = normalizeFiniteInteger(row?.Record_Losses);
@@ -1405,21 +1410,6 @@ function parseOptionalInteger(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function calculatePredictionPointsFromOdds(odds) {
-  if (odds === undefined || odds === null) {
-    return 1;
-  }
-
-  const numericOdds = Number(odds);
-  if (!Number.isFinite(numericOdds) || numericOdds === 0) {
-    return 1;
-  }
-
-  return numericOdds > 0
-    ? Math.ceil((numericOdds / 100) + 1)
-    : Math.ceil((100 / Math.abs(numericOdds)) + 1);
-}
-
 function isMainCardSegment(segment) {
   return String(segment || '').trim().toLowerCase() === 'main';
 }
@@ -1523,7 +1513,7 @@ async function recalculatePredictionResultsForEvent(eventId) {
     fetchAllFromSupabase(
       supabase
         .from('fight_results')
-        .select('fight_id, fighter_id, is_completed')
+        .select('fight_id, fighter_id, is_completed, result_type')
         .in('fight_id', fightIds)
     ),
     fetchAllFromSupabase(
@@ -1534,17 +1524,25 @@ async function recalculatePredictionResultsForEvent(eventId) {
     ),
   ]);
 
-  const completedWinnerByFightId = new Map();
+  const completedOutcomeByFightId = new Map();
   (fightResults || []).forEach((row) => {
     const fightId = Number(row?.fight_id);
-    if (!Number.isFinite(fightId) || !row?.is_completed || row?.fighter_id === null) {
+    if (!Number.isFinite(fightId) || !row?.is_completed) {
       return;
     }
-    completedWinnerByFightId.set(fightId, row.fighter_id);
+    const resultType = row.result_type
+      || (row.fighter_id !== null && row.fighter_id !== undefined ? 'winner' : null);
+    if (!['winner', 'draw', 'no_contest'].includes(resultType)) {
+      return;
+    }
+    completedOutcomeByFightId.set(fightId, {
+      resultType,
+      winnerId: resultType === 'winner' ? row.fighter_id : null,
+    });
   });
 
   const completedFights = [...fightMetaById.values()]
-    .filter((fight) => completedWinnerByFightId.has(fight.fight_id))
+    .filter((fight) => completedOutcomeByFightId.has(fight.fight_id))
     .sort(compareFightSequence);
   const allMainCardFightIds = [...fightMetaById.values()]
     .filter((fight) => isMainCardSegment(fight.card_segment))
@@ -1590,11 +1588,17 @@ async function recalculatePredictionResultsForEvent(eventId) {
         return;
       }
 
-      const predictedCorrectly = String(prediction.fighter_id) === String(completedWinnerByFightId.get(fight.fight_id));
-      let points = 0;
+      const outcome = completedOutcomeByFightId.get(fight.fight_id);
+      const baseScore = scorePredictionOutcome({
+        resultType: outcome.resultType,
+        winnerId: outcome.winnerId,
+        predictionFighterId: prediction.fighter_id,
+        bettingOdds: prediction.betting_odds,
+      });
+      const predictedCorrectly = baseScore.predictedCorrectly;
+      let points = baseScore.points;
 
       if (predictedCorrectly) {
-        points = calculatePredictionPointsFromOdds(prediction.betting_odds);
         runningCorrectStreak += 1;
 
         EVENT_STREAK_BONUS_THRESHOLDS.forEach(({ streak, bonus }) => {
@@ -2226,7 +2230,7 @@ app.get('/fights', async (req, res) => {
     // Get fight results
     const { data: fightResults, error: resultsError } = await supabase
       .from('fight_results')
-      .select('fight_id, fighter_id');
+      .select('fight_id, fighter_id, is_completed, result_type');
 
     if (resultsError) {
       console.error('Error fetching fight results:', resultsError);
@@ -2236,8 +2240,7 @@ app.get('/fights', async (req, res) => {
     // Create a map of fight results
     const fightResultsMap = new Map();
     fightResults.forEach(result => {
-      const { fight_id, fighter_id } = result;
-      fightResultsMap.set(fight_id, fighter_id);
+      fightResultsMap.set(result.fight_id, result);
     });
 
     // Group fighters by FightId
@@ -2428,7 +2431,7 @@ app.get('/predictions/history', requireUserSession, async (req, res) => {
 
     const fightResultsQuery = supabase
       .from('fight_results')
-      .select('fight_id, fighter_id, is_completed')
+      .select('fight_id, fighter_id, is_completed, result_type')
       .in('fight_id', fightIds);
     const fightResults = await fetchAllFromSupabase(fightResultsQuery);
     const fightResultMap = new Map(
@@ -2436,7 +2439,8 @@ app.get('/predictions/history', requireUserSession, async (req, res) => {
         Number(result.fight_id),
         {
           winner: result.fighter_id,
-          is_completed: Boolean(result.is_completed)
+          is_completed: Boolean(result.is_completed),
+          result_type: result.result_type,
         }
       ])
     );
@@ -2460,8 +2464,9 @@ app.get('/predictions/history', requireUserSession, async (req, res) => {
           event_id: eventId,
           event_date: eventId ? (eventDateMap.get(eventId) || null) : null,
           winner,
+          result_type: result?.result_type || (winner !== null ? 'winner' : null),
           is_completed: isCompleted,
-          fighter_won: fighterWon
+          fighter_won: fighterWon,
         };
       })
       .sort((a, b) => {
@@ -2807,14 +2812,15 @@ app.post('/ufc_full_fight_card/:id/cancel', requireAdminSession, async (req, res
 app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res) => {
   try {
     const { id } = req.params;
-    const { winner } = req.body;
+    const { winner, result_type: requestedResultType } = req.body;
 
     debugLog('Received request to update fight result:', {
       id,
       idType: typeof id,
       idLength: id.length,
       winner,
-      winnerType: typeof winner
+      winnerType: typeof winner,
+      requestedResultType,
     });
 
     // First get the fight data to get the event_id and fighter IDs
@@ -2841,9 +2847,22 @@ app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res
       return res.status(404).json({ error: 'Missing fighter data' });
     }
 
-    // Determine the winner's fighter_id
+    const inferredResultType = requestedResultType
+      || (winner !== null && winner !== undefined && winner !== '' ? 'winner' : null);
+    if (inferredResultType !== null && !['winner', 'draw', 'no_contest'].includes(inferredResultType)) {
+      return res.status(400).json({ error: 'Result type must be winner, draw, or no_contest' });
+    }
+
+    if (inferredResultType !== 'winner' && winner !== null && winner !== undefined && winner !== '') {
+      return res.status(400).json({ error: 'Draw and no contest results cannot include a winner' });
+    }
+
+    // Determine the winner's fighter_id for winner outcomes.
     let winner_id = null;
-    if (winner !== null && winner !== undefined && winner !== '') {
+    if (inferredResultType === 'winner') {
+      if (winner === null || winner === undefined || winner === '') {
+        return res.status(400).json({ error: 'Winner id is required for a winner result' });
+      }
       winner_id = Number(winner);
       if (!Number.isFinite(winner_id)) {
         return res.status(400).json({ error: 'Invalid winner id' });
@@ -2860,7 +2879,7 @@ app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res
 
     const { data: existingResult, error: existingResultError } = await supabase
       .from('fight_results')
-      .select('fight_id, fighter_id, is_completed')
+      .select('fight_id, fighter_id, is_completed, result_type')
       .eq('fight_id', id)
       .maybeSingle();
 
@@ -2869,14 +2888,17 @@ app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res
       return res.status(500).json({ error: 'Failed to fetch existing fight result' });
     }
 
-    // Update fight_results table with fighter_id
+    const isCompleted = inferredResultType !== null;
+
+    // Store the completed outcome; neutral outcomes intentionally have no fighter_id.
     const { error: updateError } = await supabase
       .from('fight_results')
       .upsert([
         {
           fight_id: id,
           fighter_id: winner_id,
-          is_completed: winner_id !== null
+          is_completed: isCompleted,
+          result_type: inferredResultType,
         }
       ], {
         onConflict: ['fight_id']
@@ -2895,7 +2917,11 @@ app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res
     const previousWinnerId = existingResult?.is_completed && existingResult?.fighter_id !== null
       ? Number(existingResult.fighter_id)
       : null;
-    const resultChanged = previousWinnerId !== winner_id;
+    const previousResultType = existingResult?.result_type
+      || (previousWinnerId !== null ? 'winner' : null);
+    const resultChanged = previousWinnerId !== winner_id
+      || previousResultType !== inferredResultType
+      || Boolean(existingResult?.is_completed) !== isCompleted;
 
     if (resultChanged) {
       try {
@@ -2915,6 +2941,7 @@ app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res
         event_id,
         updated_fight_id: id,
         winner_id,
+        result_type: inferredResultType,
         rowCount: recalculatedResults.rowCount,
       });
     } catch (predictionResultsError) {
@@ -2925,7 +2952,7 @@ app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res
     // Get the updated fight result
     const { data: updatedResult, error: getResultError } = await supabase
       .from('fight_results')
-      .select('fight_id, fighter_id, is_completed')
+      .select('fight_id, fighter_id, is_completed, result_type')
       .eq('fight_id', id)
       .single();
 
@@ -2955,7 +2982,8 @@ app.post('/ufc_full_fight_card/:id/result', requireAdminSession, async (req, res
         fight_id: id,
         event_id,
         winner_id,
-        is_completed: winner_id !== null,
+        result_type: inferredResultType,
+        is_completed: isCompleted,
         fighter_streak_sync: fighterStreakSync,
       },
     });
@@ -4154,7 +4182,7 @@ app.post('/admin/events/:id/fight-card/preview', requireAdminSession, async (req
     if (existingFightIds.length > 0) {
       const { data, error } = await supabase
         .from('fight_results')
-        .select('fight_id, fighter_id, is_completed')
+        .select('fight_id, fighter_id, is_completed, result_type')
         .in('fight_id', existingFightIds);
 
       if (error) {
@@ -5474,7 +5502,7 @@ app.get('/events/:id/fights', async (req, res) => {
     // Get only the selected event's fight results so live refreshes stay lightweight.
     const { data: fightResults, error: resultsError } = await supabase
       .from('fight_results')
-      .select('fight_id, fighter_id, is_completed')
+      .select('fight_id, fighter_id, is_completed, result_type')
       .in('fight_id', fightIds);
 
     if (resultsError) {
@@ -5488,7 +5516,8 @@ app.get('/events/:id/fights', async (req, res) => {
       const numericFightId = Number(result.fight_id);
       fightResultsMap.set(numericFightId, {
         winner: result.fighter_id,
-        is_completed: result.is_completed
+        is_completed: result.is_completed,
+        result_type: result.result_type,
       });
     });
 
@@ -5572,7 +5601,7 @@ app.get('/events/:id/picks-context', requireUserSession, async (req, res) => {
     }
 
     const [resultsResult, predictions, users, remindersResult, userPredictionRows] = await Promise.all([
-      supabase.from('fight_results').select('fight_id, fighter_id, is_completed').in('fight_id', fightIds),
+      supabase.from('fight_results').select('fight_id, fighter_id, is_completed, result_type').in('fight_id', fightIds),
       fetchAllFromSupabase(supabase.from('predictions').select('fight_id, fighter_id, user_id, username').in('fight_id', fightIds)),
       fetchAllUsers('user_id, username, is_bot'),
       supabase.from('fighter_vote_reminders').select('fighter_id, fighter_name, reminder_type, created_at, updated_at').eq('user_id', req.authenticatedUser.user_id).order('updated_at', { ascending: false }),
@@ -5598,7 +5627,11 @@ app.get('/events/:id/picks-context', requireUserSession, async (req, res) => {
         eventDate: eventData.date || null,
         redFighter: group.red,
         blueFighter: group.blue,
-        result: result ? { winner: result.fighter_id, is_completed: result.is_completed } : null,
+        result: result ? {
+          winner: result.fighter_id,
+          is_completed: result.is_completed,
+          result_type: result.result_type,
+        } : null,
         weightclassMap,
       })];
     });
@@ -5617,7 +5650,7 @@ app.get('/events/:id/picks-context', requireUserSession, async (req, res) => {
       const eventDates = new Map(historyEvents.map((event) => [Number(event.id), event.date]));
       historyFightMeta = historyRows.map((row) => ({ ...row, event_date: eventDates.get(Number(row.EventId)) || null }));
       historyResults = await fetchAllFromSupabase(
-        supabase.from('fight_results').select('fight_id, fighter_id, is_completed').in('fight_id', historyFightIds)
+        supabase.from('fight_results').select('fight_id, fighter_id, is_completed, result_type').in('fight_id', historyFightIds)
       );
     }
 
@@ -6436,7 +6469,7 @@ app.get('/events/:id/friend-comparison', requireUserSession, async (req, res) =>
           fetchAllFromSupabase(
             supabase
               .from('fight_results')
-              .select('fight_id, fighter_id, is_completed')
+              .select('fight_id, fighter_id, is_completed, result_type')
               .in('fight_id', fightIds)
           ),
         ])
@@ -6512,7 +6545,7 @@ app.get('/events/:id/recap', async (req, res) => {
           fetchAllFromSupabase(
             supabase
               .from('fight_results')
-              .select('fight_id, fighter_id, is_completed')
+              .select('fight_id, fighter_id, is_completed, result_type')
               .in('fight_id', fightIds)
           ),
         ])
@@ -6832,7 +6865,7 @@ app.get('/ufc_full_fight_card/:id', async (req, res) => {
     // Get the fight result (keep .single() here)
     const { data: fightResult, error: getResultError } = await supabase
       .from('fight_results')
-      .select('fight_id, fighter_id, is_completed')
+      .select('fight_id, fighter_id, is_completed, result_type')
       .eq('fight_id', id)
       .single();
 

--- a/Server/lib/eventFriendComparison.js
+++ b/Server/lib/eventFriendComparison.js
@@ -184,6 +184,9 @@ function buildEventFriendComparison({
     const result = resultsByFight.get(fight.fight_id) || null;
     const isCompleted = Boolean(result?.is_completed);
     const winnerId = isCompleted ? normalizeId(result?.fighter_id) : null;
+    const resultType = isCompleted
+      ? (result?.result_type || (winnerId ? 'winner' : null))
+      : null;
     const isVisible = Boolean(viewerPrediction) || isCompleted;
     const viewerPick = toPick(viewerPrediction, fight, viewerId, isCompleted, winnerId);
     const friendPick = isVisible
@@ -205,6 +208,7 @@ function buildEventFriendComparison({
       card_segment: fight.card_segment,
       matchup: [...fight.fighters.values()],
       is_completed: isCompleted,
+      result_type: resultType,
       is_canceled: fight.is_canceled,
       is_visible: isVisible,
       comparison_state: comparisonState,

--- a/Server/lib/fightResponse.js
+++ b/Server/lib/fightResponse.js
@@ -131,15 +131,21 @@ function resolveFightResult(result) {
       ? result.winner
       : result.fighter_id;
 
+    const isCompleted = result.is_completed ?? Boolean(winner);
+    const resultType = result.result_type
+      || (isCompleted && winner !== null && winner !== undefined ? 'winner' : null);
+
     return {
-      winner: winner || null,
-      is_completed: result.is_completed ?? Boolean(winner),
+      winner: winner ?? null,
+      is_completed: isCompleted,
+      result_type: resultType,
     };
   }
 
   return {
-    winner: result || null,
+    winner: result ?? null,
     is_completed: Boolean(result),
+    result_type: result ? 'winner' : null,
   };
 }
 
@@ -214,6 +220,7 @@ function buildFightResponse({
     fighter2_decision_losses: blue.decisionLosses,
     winner: resolvedResult.winner,
     is_completed: resolvedResult.is_completed,
+    result_type: resolvedResult.result_type,
     is_canceled: redFighter?.FightStatus === 'Canceled' || blueFighter?.FightStatus === 'Canceled',
     fight_status: fightStatus,
     card_tier: normalizeCardTier(redFighter?.CardSegment),

--- a/Server/lib/picksContext.js
+++ b/Server/lib/picksContext.js
@@ -48,8 +48,11 @@ function buildPriorPickOutcomes({ predictions = [], fightMeta = [], results = []
         event_id: meta?.EventId || null,
         event_date: meta?.event_date || null,
         winner: result.fighter_id ?? null,
+        result_type: result.result_type || (result.fighter_id != null ? 'winner' : null),
         is_completed: true,
-        fighter_won: String(result.fighter_id) === String(prediction.fighter_id),
+        fighter_won: result.fighter_id == null
+          ? null
+          : String(result.fighter_id) === String(prediction.fighter_id),
       };
     })
     .filter(Boolean)

--- a/Server/lib/predictionScoring.js
+++ b/Server/lib/predictionScoring.js
@@ -1,0 +1,27 @@
+function calculatePredictionPointsFromOdds(odds) {
+  if (odds === undefined || odds === null) return 1;
+
+  const numericOdds = Number(odds);
+  if (!Number.isFinite(numericOdds) || numericOdds === 0) return 1;
+
+  return numericOdds > 0
+    ? Math.ceil((numericOdds / 100) + 1)
+    : Math.ceil((100 / Math.abs(numericOdds)) + 1);
+}
+
+function scorePredictionOutcome({ resultType, winnerId, predictionFighterId, bettingOdds }) {
+  const predictedCorrectly = resultType === 'winner'
+    && winnerId !== null
+    && winnerId !== undefined
+    && String(predictionFighterId) === String(winnerId);
+
+  return {
+    predictedCorrectly,
+    points: predictedCorrectly ? calculatePredictionPointsFromOdds(bettingOdds) : 0,
+  };
+}
+
+module.exports = {
+  calculatePredictionPointsFromOdds,
+  scorePredictionOutcome,
+};

--- a/Server/test/eventFriendComparison.test.js
+++ b/Server/test/eventFriendComparison.test.js
@@ -89,3 +89,30 @@ test('returns a stable empty comparison when no friend has picked the card', () 
   assert.deepEqual(comparison.fights, []);
   assert.equal(comparison.summary.locked_fights, 3);
 });
+
+test('preserves neutral completed outcomes with zero-point picks', () => {
+  const comparison = buildEventFriendComparison({
+    viewerUserId: 1,
+    friendUserId: 2,
+    users,
+    fightRows,
+    predictions: [
+      { fight_id: 20, fighter_id: 201, user_id: 1 },
+      { fight_id: 20, fighter_id: 202, user_id: 2 },
+    ],
+    predictionResults: [
+      { fight_id: 20, user_id: 1, predicted_correctly: false, points: 0 },
+      { fight_id: 20, user_id: 2, predicted_correctly: false, points: 0 },
+    ],
+    fightResults: [{ fight_id: 20, fighter_id: null, is_completed: true, result_type: 'draw' }],
+  });
+
+  const draw = comparison.fights.find((fight) => fight.fight_id === '20');
+  assert.equal(draw.is_completed, true);
+  assert.equal(draw.result_type, 'draw');
+  assert.equal(draw.winner, null);
+  assert.equal(draw.viewer_pick.points, 0);
+  assert.equal(draw.viewer_pick.is_correct, null);
+  assert.equal(draw.friend_pick.points, 0);
+  assert.equal(draw.friend_pick.is_correct, null);
+});

--- a/Server/test/fightResponse.test.js
+++ b/Server/test/fightResponse.test.js
@@ -115,9 +115,24 @@ test('buildFightResponse keeps fight metadata and title round fields', () => {
   assert.equal(response.fighter2_style, 'Wrestling');
   assert.equal(response.winner, 2);
   assert.equal(response.is_completed, true);
+  assert.equal(response.result_type, 'winner');
   assert.equal(response.card_tier, 'Prelims');
   assert.equal(response.weightclass, 'Lightweight Bangers');
   assert.equal(response.scheduled_rounds, 5);
   assert.equal(response.is_title_fight, true);
   assert.equal(response.title_fight_name, 'Interim Belt');
+});
+
+test('buildFightResponse preserves completed neutral outcomes without a winner', () => {
+  const response = buildFightResponse({
+    fightId: 123,
+    eventId: 99,
+    redFighter,
+    blueFighter,
+    result: { fighter_id: null, is_completed: true, result_type: 'no_contest' },
+  });
+
+  assert.equal(response.winner, null);
+  assert.equal(response.is_completed, true);
+  assert.equal(response.result_type, 'no_contest');
 });

--- a/Server/test/picksContext.test.js
+++ b/Server/test/picksContext.test.js
@@ -61,3 +61,16 @@ test('buildPicksContextPayload returns stable empty collections', () => {
     prior_pick_outcomes: [],
   });
 });
+
+test('buildPriorPickOutcomes treats a neutral result as completed without a loss', () => {
+  const outcomes = buildPriorPickOutcomes({
+    predictions: [{ fight_id: 1, fighter_id: 11 }],
+    fightMeta: [{ FightId: 1, EventId: 100, event_date: '2026-01-01' }],
+    results: [{ fight_id: 1, fighter_id: null, is_completed: true, result_type: 'draw' }],
+    selectedEventDate: '2026-08-01',
+  });
+
+  assert.equal(outcomes.length, 1);
+  assert.equal(outcomes[0].result_type, 'draw');
+  assert.equal(outcomes[0].fighter_won, null);
+});

--- a/Server/test/predictionScoring.test.js
+++ b/Server/test/predictionScoring.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { scorePredictionOutcome } = require('../lib/predictionScoring');
+
+test('awards odds-based points only for the winning fighter', () => {
+  assert.deepEqual(scorePredictionOutcome({
+    resultType: 'winner',
+    winnerId: 101,
+    predictionFighterId: 101,
+    bettingOdds: 250,
+  }), { predictedCorrectly: true, points: 4 });
+});
+
+test('draws and no contests award zero points to either pick', () => {
+  for (const resultType of ['draw', 'no_contest']) {
+    assert.deepEqual(scorePredictionOutcome({
+      resultType,
+      winnerId: null,
+      predictionFighterId: 101,
+      bettingOdds: 250,
+    }), { predictedCorrectly: false, points: 0 });
+    assert.deepEqual(scorePredictionOutcome({
+      resultType,
+      winnerId: null,
+      predictionFighterId: 102,
+      bettingOdds: -300,
+    }), { predictedCorrectly: false, points: 0 });
+  }
+});

--- a/supabase/migrations/20260821214309_add_fight_result_type.sql
+++ b/supabase/migrations/20260821214309_add_fight_result_type.sql
@@ -1,0 +1,16 @@
+ALTER TABLE public.fight_results
+  ADD COLUMN IF NOT EXISTS result_type text;
+
+UPDATE public.fight_results
+SET result_type = 'winner'
+WHERE is_completed = true
+  AND fighter_id IS NOT NULL
+  AND result_type IS NULL;
+
+ALTER TABLE public.fight_results
+  DROP CONSTRAINT IF EXISTS fight_results_result_type_check,
+  ADD CONSTRAINT fight_results_result_type_check
+    CHECK (result_type IS NULL OR result_type IN ('winner', 'draw', 'no_contest'));
+
+COMMENT ON COLUMN public.fight_results.result_type IS
+  'Completed fight outcome: winner, draw, or no_contest. Null represents an unset result.';


### PR DESCRIPTION
- Introduced 'result_type' column in fight_results to track outcomes: winner, draw, or no contest.
- Updated fight result handling to accommodate new result types, ensuring draws and no contests are processed correctly.
- Enhanced admin controls for fight results to include options for draw and no contest.
- Adjusted frontend components to reflect new result types and ensure accurate display of fight outcomes.
- Added tests to verify correct handling of neutral outcomes and scoring logic based on fight results.